### PR TITLE
Automated scenario 1, 2a and 2b from LL-613

### DIFF
--- a/test/features/ContractorEngagement/ContractorEngagement.feature
+++ b/test/features/ContractorEngagement/ContractorEngagement.feature
@@ -155,3 +155,52 @@ Feature: Contractor Engagement features
   | LLAdmin@looped.in  | Octopus@6  |   6155      |  Interpreter   | ASSYRIAN | ENGLISH  | Recognised Practising Interpreter  |CPN9LK67K|
   | LLAdmin@looped.in  | Octopus@6  |   6268      |  Translator    | ASSYRIAN | ENGLISH  | 3-into English                     |CPN7CL35L|
   | LLAdmin@looped.in  | Octopus@6  |   6268      |  Translator    | ENGLISH  | ASSYRIAN | 3-from English                     |CPN7CL35L|
+
+   #Block COVID Vax Exemption UI Scenario 1: Admin user clicks Add a Block
+ @BlockCovidVaxExemption @AdminClicksAddBlock
+ Scenario Outline: Block COVID Vax Exemption UI Admin user clicks Add a Block
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and open contractor "<contractor>"
+  And the admin is on the Contractor Profile page
+  And the admin clicks on Add a Block
+  Then the Contractor Blocking modal popup pops-up
+  And there should be 3 Tabs : "<contractorPopupTab1>", "<contractorPopupTab2>", "<contractorPopupTab3>"
+
+  Examples:
+   | username           |  password |  contractor   | contractorPopupTab1 | contractorPopupTab2 | contractorPopupTab3 |
+   | LLAdmin@looped.in  | Octopus@6  | Automation   | Organisation        | Campus              | Bill-To             |
+
+  #Block COVID Vax Exemption UI Scenario 2a: Admin user clicks on the Bill To tab
+ @BlockCovidVaxExemption @AdminClicksBillTo
+ Scenario Outline: Block COVID Vax Exemption UI Admin user clicks on the Bill To tab
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and open contractor "<contractor>"
+  And the admin clicks on Add a Block
+  And the Contractor Blocking modal popup pops-up
+  And the admin clicks on the Bill To tab
+  Then it should show a list of Contract Bill To’s
+  And the search box should allow the admin to filter by Bill To name "<billToName>"
+  And the user can select 1 or more Bill Tos
+
+  Examples:
+   | username           |  password |  contractor   | billToName                    |
+   | LLAdmin@looped.in  | Octopus@6  | Automation   | Catholic Education - User Pay |
+
+
+   #Block COVID Vax Exemption UI Scenario 2b: Job Types Selection
+ @BlockCovidVaxExemption @JobTypesSelection
+ Scenario Outline: Block COVID Vax Exemption UI Job Types Selection
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and open contractor "<contractor>"
+  And the admin clicks on Add a Block
+  And the Contractor Blocking modal popup pops-up
+  And the admin clicks on the Bill To tab
+  Then it should show a list of Job Types, each with a checkbox
+  And each should be default checked
+
+  Examples:
+   | username           |  password |  contractor   |
+   | LLAdmin@looped.in  | Octopus@6  | Automation   |

--- a/test/pages/ContractorEngagement/ContractorEngagement.js
+++ b/test/pages/ContractorEngagement/ContractorEngagement.js
@@ -382,6 +382,49 @@ module.exports = {
 
     get contractorSearchResultLocator(){
         return '//table[contains(@id,"Contractor")]//td/a[contains(text(),"<dynamic>")]'
-    }
-    
+    },
+
+    get addABlockLink() {
+        return $('//a[text()="Add a block"]');
+    },
+
+    get contractorBlockingModalPopup() {
+        return $('//span[text()="Contractor Blocking"]//parent::div/parent::div[contains(@id,"block_Modal")]');
+    },
+
+    get contractorBlockPopupTabs() {
+        return $('//div[contains(@id,"block_Modal")]//div[@class="Tabs_header noSwipe "]');
+    },
+
+    get billToTab() {
+        return $('//div[text()="Bill-To" and contains(@class,"Tabs__tab PH")]');
+    },
+
+    get listOfContractBillTos() {
+        return $('//span[@class="ListRecords" and contains(@id,"BillTos")]');
+    },
+
+    get billToSearchBox() {
+        return $('//input[contains(@id,"SearchBillTo")]');
+    },
+
+    get billToCheckBoxesCount() {
+        return $$('//input[@type="checkbox" and contains(@id,"BillTos")]').length;
+    },
+
+    get billToCheckBoxes() {
+        return $$('//input[@type="checkbox" and contains(@id,"BillTos")]');
+    },
+
+    get jobTypesListRecords() {
+        return $('//span[@class="ListRecords" and contains(@id,"ListRecords1")]');
+    },
+
+    get jobTypesCheckBoxesCount() {
+        return $$('//input[@type="checkbox" and contains(@id,"ListRecords1")]').length;
+    },
+
+    get jobTypesCheckBoxes() {
+        return $$('//input[@type="checkbox" and contains(@id,"ListRecords1")]');
+    },
 }

--- a/test/stepdefinition/ContractorEngagement/ContractorEngagementSteps.js
+++ b/test/stepdefinition/ContractorEngagement/ContractorEngagementSteps.js
@@ -346,3 +346,78 @@ Then(/^I see any naati accreditation already present$/, function() {
     }
 }
 })
+
+Given(/^the admin is on the Contractor Profile page$/, function () {
+    let currentPageUrl = action.getPageUrl();
+    chai.expect(currentPageUrl).to.includes("PreviewContractorProfile.aspx");
+})
+
+When(/^the admin clicks on Add a Block$/, function () {
+    action.isVisibleWait(contractorEngagementPage.addABlockLink, 10000);
+    action.clickElement(contractorEngagementPage.addABlockLink);
+})
+
+Then(/^the Contractor Blocking modal popup pops-up$/, function () {
+    let contractorBlockModalPopupDisplayStatus = action.isVisibleWait(contractorEngagementPage.contractorBlockingModalPopup, 10000);
+    chai.expect(contractorBlockModalPopupDisplayStatus).to.be.true;
+})
+
+Then(/^there should be 3 Tabs : "(.*)", "(.*)", "(.*)"$/, function (tab1Expected, tab2Expected, tab3Expected) {
+    let contractorBlockPopupTabsActual = action.getElementText(contractorEngagementPage.contractorBlockPopupTabs);
+    chai.expect(contractorBlockPopupTabsActual).to.includes(tab1Expected);
+    chai.expect(contractorBlockPopupTabsActual).to.includes(tab2Expected);
+    chai.expect(contractorBlockPopupTabsActual).to.includes(tab3Expected);
+})
+
+When(/^the admin clicks on the Bill To tab$/, function () {
+    action.isVisibleWait(contractorEngagementPage.billToTab, 10000);
+    action.clickElement(contractorEngagementPage.billToTab);
+})
+
+Then(/^it should show a list of Contract Bill To’s$/, function () {
+    let contractBillTosDisplayStatus = action.isVisibleWait(contractorEngagementPage.listOfContractBillTos, 10000);
+    chai.expect(contractBillTosDisplayStatus).to.be.true;
+})
+
+Then(/^the search box should allow the admin to filter by Bill To name "(.*)"$/, function (billToNameSearch) {
+    action.isVisibleWait(contractorEngagementPage.billToSearchBox, 10000);
+    action.addValueAndPressReturnTab(contractorEngagementPage.billToSearchBox, billToNameSearch);
+    let contractBillTosTextActual = action.getElementText(contractorEngagementPage.listOfContractBillTos, 10000);
+    chai.expect(contractBillTosTextActual).to.includes(billToNameSearch);
+})
+
+Then(/^the user can select 1 or more Bill Tos$/, function () {
+    action.clearValue(contractorEngagementPage.billToSearchBox);
+    browser.waitUntil(
+        () => contractorEngagementPage.billToCheckBoxesCount > 1,
+        {
+            timeout: 20000,
+            timeoutMsg: 'expected all Bill To checkboxes to display'
+        }
+    );
+    let billToCheckboxesCount = contractorEngagementPage.billToCheckBoxesCount;
+    for (let checkBoxIndex = 0; checkBoxIndex < billToCheckboxesCount; checkBoxIndex++) {
+        let checkBoxElements = contractorEngagementPage.billToCheckBoxes;
+        action.isVisibleWait(checkBoxElements[checkBoxIndex], 10000);
+        action.clickElement(checkBoxElements[checkBoxIndex]);
+        //short pause to let the checkboxes get selected
+        browser.pause(2000);
+        let checkBoxSelectedStatus = action.isSelectedWait(checkBoxElements[checkBoxIndex], 10000);
+        chai.expect(checkBoxSelectedStatus).to.be.true;
+    }
+})
+
+Then(/^it should show a list of Job Types, each with a checkbox$/, function () {
+    let jobTypesListDisplayStatus = action.isVisibleWait(contractorEngagementPage.jobTypesListRecords, 10000);
+    chai.expect(jobTypesListDisplayStatus).to.be.true;
+})
+
+Then(/^each should be default checked$/, function () {
+    let jobTypesCheckboxesCount = contractorEngagementPage.jobTypesCheckBoxesCount;
+    for (let checkBoxIndex = 0; checkBoxIndex < jobTypesCheckboxesCount; checkBoxIndex++) {
+        let checkBoxElements = contractorEngagementPage.jobTypesCheckBoxes;
+        action.isVisibleWait(checkBoxElements[checkBoxIndex], 10000);
+        let checkBoxSelectedStatus = action.isSelectedWait(checkBoxElements[checkBoxIndex], 10000);
+        chai.expect(checkBoxSelectedStatus).to.be.true;
+    }
+})


### PR DESCRIPTION
- Added new locators in contractor engagement page for add a block modal popup elements.
- Added reusable step methods to click add a block on the Contractor Profile, verify the 3 Tabs on Contractor Blocking modal popup, to verify list of Contract Bill To’s and Job Types and their respective checkboxes selected in Bill-To tab.
- Automated scenario 1, scenario 2a and scenario 2b from LL-613 ticket under 22.04-1 release version.