### PR TITLE
Automated scenario 1b from LL-666 ticket and fixed failures

### DIFF
--- a/test/features/BookingManagement/Bookings.feature
+++ b/test/features/BookingManagement/Bookings.feature
@@ -284,6 +284,8 @@ Feature: Create new booking for Interpreters
     And the Job Campus belongs to a certain BillTo "<campus PinBillToCode>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
+    And Add Naati Accreditation "<service>","<from>","<to>","<level>" if not available
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -321,8 +323,8 @@ Feature: Create new booking for Interpreters
     And the block "<billTo>" sadly disappears from the list…
 
     Examples:
-      | username          | password  | campus id | campus PinBillToCode | contractor | billTo          | severityLevel | jobTypes      | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | status       |
-      | LLAdmin@looped.in | Octopus@6 | 33124     |  33124 - DH006       | Automation | DH006 - DH RDNS | 1             | Pre-booked TI | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Not eligible |
+      | username          | password  | campus id | campus PinBillToCode | contractor | service     | from      | to      | level        | billTo          | severityLevel | jobTypes      | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | status       |
+      | LLAdmin@looped.in | Octopus@6 | 33124     |  33124 - DH006       | Automation | Interpreter | zz-Zenq2  | ENGLISH | Professional | DH006 - DH RDNS | 1             | Pre-booked TI | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Not eligible |
 
     #LL-682 Covid vax exemption allocation logic Scenario 1b: The contractor is not Blocked from a Job Type
     #GIVEN a User has requested Prebooked job > AND the Job Campus belongs to a certain BillTo > AND they are not blocked from a Job Type
@@ -336,6 +338,8 @@ Feature: Create new booking for Interpreters
     And the Job Campus belongs to a certain BillTo "<campus PinBillToCode>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
+    And Add Naati Accreditation "<service>","<from>","<to>","<level>" if not available
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -373,8 +377,8 @@ Feature: Create new booking for Interpreters
     And the block "<billTo>" sadly disappears from the list…
 
     Examples:
-      | username          | password  | campus id | campus PinBillToCode | contractor | billTo          | severityLevel | jobTypes      | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | status            |
-      | LLAdmin@looped.in | Octopus@6 | 33124     |  33124 - DH006       | Automation | DH006 - DH RDNS | 1             | On Site       | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Auto Notification |
+      | username          | password  | campus id | campus PinBillToCode | contractor | service     | from      | to      | level        | billTo          | severityLevel | jobTypes      | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | status            |
+      | LLAdmin@looped.in | Octopus@6 | 33124     |  33124 - DH006       | Automation | Interpreter | zz-Zenq2  | ENGLISH | Professional | DH006 - DH RDNS | 1             | On Site       | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Auto Notification |
 
     #LL-682 Covid vax exemption allocation logic Scenario 2: The contractor is not blocked
     #GIVEN a User has requested Prebooked job > AND the Job Campus belongs to a certain BillTo >
@@ -388,6 +392,8 @@ Feature: Create new booking for Interpreters
     And the Job Campus belongs to a certain BillTo "<campus PinBillToCode>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
+    And Add Naati Accreditation "<service>","<from>","<to>","<level>" if not available
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -425,5 +431,5 @@ Feature: Create new booking for Interpreters
     And the block "<billTo>" sadly disappears from the list…
 
     Examples:
-      | username          | password  | campus id | campus PinBillToCode | contractor | billTo                                   | severityLevel | jobTypes      | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | status            |
-      | LLAdmin@looped.in | Octopus@6 | 33124     |  33124 - DH006       | Automation | UserPay1 - Catholic Education - User Pay | 1             | On Site       | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Auto Notification |
+      | username          | password  | campus id | campus PinBillToCode | contractor | service     | from      | to      | level        | billTo                                   | severityLevel | jobTypes      | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | status            |
+      | LLAdmin@looped.in | Octopus@6 | 33124     |  33124 - DH006       | Automation | Interpreter | zz-Zenq2  | ENGLISH | Professional | UserPay1 - Catholic Education - User Pay | 1             | On Site       | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Auto Notification |

--- a/test/features/ContractorEngagement/ContractorEngagement.feature
+++ b/test/features/ContractorEngagement/ContractorEngagement.feature
@@ -348,3 +348,16 @@ Feature: Contractor Engagement features
     Examples:
       | username          | password  | contractor | billTo                                   | severityLevel | startDate  | endDate    |
       | LLAdmin@looped.in | Octopus@6 | Automation | UserPay1 - Catholic Education - User Pay | 1             | 05-02-2023 | 06-02-2023 |
+
+    #LL-666 NAATI - Dual Certification Scenario 1b: 1 active NAATI accreditation
+  @NaatiDualCertification @OneActiveNaati
+  Scenario Outline: Block COVID Vax Exemption UI Block Expires
+    When I login with "<username>" and "<password>"
+    And I click contractor engagement link
+    And I search and open contractor "<contractor>"
+    And the Interpreter has one active NAATI accreditations for a language "<from>" to "<to>"
+    Then on Contractor Details History page, the NAATI accreditation "<Naati Accreditation>" will have been allocated to the interpreter’s profile
+
+    Examples:
+      | username          | password  | contractor    | Naati Accreditation               | from      | to      |
+      | LLAdmin@looped.in | Octopus@6 | Abir ISKANDAR | Certified Provisional Interpreter | ARABIC    | ENGLISH |

--- a/test/features/ContractorEngagement/ContractorEngagement.feature
+++ b/test/features/ContractorEngagement/ContractorEngagement.feature
@@ -162,6 +162,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin is on the Contractor Profile page
     And the admin clicks on Add a Block
     Then the Contractor Blocking modal popup pops-up
@@ -177,6 +178,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -195,6 +197,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -211,6 +214,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -233,6 +237,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -255,6 +260,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -274,6 +280,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -302,6 +309,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab
@@ -323,6 +331,7 @@ Feature: Contractor Engagement features
     When I login with "<username>" and "<password>"
     And I click contractor engagement link
     And I search and open contractor "<contractor>"
+    And the admin clicks on Remove on a block
     And the admin clicks on Add a Block
     And the Contractor Blocking modal popup pops-up
     And the admin clicks on the Bill To tab

--- a/test/pages/ContractorEngagement/ContractorEngagement.js
+++ b/test/pages/ContractorEngagement/ContractorEngagement.js
@@ -476,5 +476,41 @@ module.exports = {
 
     get saveButtonOnBlockingPopup() {
         return $('//input[contains(@id,"blockingDialog") and (@value="Save")]')
-    }
+    },
+
+    get accreditationFromToLanguagesLocator() {
+        return '//table[contains(@id,"NAATIAccreditation")]/tbody/tr/td[2][text()="<dynamic1> > <dynamic2>"]';
+    },
+
+    get accreditationFromToLanguagesServiceLinkLocator() {
+        return '//table[contains(@id,"NAATIAccreditation")]/tbody/tr/td[2][text()="<dynamic1> > <dynamic2>"]/preceding-sibling::td/a';
+    },
+
+    get viewHistoryButton() {
+        return $('//input[@value="View History" and (@class="Button")]');
+    },
+
+    get showContractAuditTrialsLink() {
+        return $('//a[text()="Show Contractor Audit Trails"]');
+    },
+
+    get auditHistoryNoItemsToShowMessage() {
+        return $('//td[text()="No items to show..."]');
+    },
+
+    get auditHistoryTableBody() {
+        return $('//table[contains(@id,"AuditHistory")]/tbody');
+    },
+
+    get naatiCertificationsText() {
+        return $$('//span[contains(@id,"Certifications")]/div');
+    },
+
+    get cancelButtonOnNaatiAcceditationPopup() {
+        return $('//input[@value="Cancel" and contains(@id,"dialogAccreditation")]')
+    },
+
+    get naatiCertificationsFirstText() {
+        return $('//span[contains(@id,"Certifications")]/div');
+    },
 }

--- a/test/stepdefinition/ContractorEngagement/ContractorEngagementSteps.js
+++ b/test/stepdefinition/ContractorEngagement/ContractorEngagementSteps.js
@@ -602,3 +602,39 @@ When(/^the expiry date "(.*)", "(.*)" is prior to the current date$/, function (
     action.isVisibleWait(contractorEngagementPage.saveButtonOnBlockingPopup, 10000);
     action.clickElement(contractorEngagementPage.saveButtonOnBlockingPopup);
 })
+
+When(/^Add Naati Accreditation "(.*)","(.*)","(.*)","(.*)" if not available$/, function (service, from, to, level) {
+    let accreditationFromToLanguagesAvailable = $(contractorEngagementPage.accreditationFromToLanguagesLocator.replace("<dynamic1>",from).replace("<dynamic2>",to));
+    if (action.isVisibleWait(accreditationFromToLanguagesAvailable,1000) === false){
+        action.isVisibleWait(contractorEngagementPage.addAccreditationLink,10000);
+        action.clickElement(contractorEngagementPage.addAccreditationLink);
+        action.isVisibleWait(contractorEngagementPage.serviceDropdown,10000);
+        action.selectTextFromDropdown(contractorEngagementPage.serviceDropdown, service);
+        action.enterValueAndPressReturn(contractorEngagementPage.fromLanguageDropdown, from);
+        action.enterValueAndPressReturn(contractorEngagementPage.toLanguageDropdown, to);
+        action.selectTextFromDropdown(contractorEngagementPage.naatiAccreditationDropdown, level);
+        action.clickElement(contractorEngagementPage.saveAndCloseButton);
+    }
+})
+
+When(/^the Interpreter has one active NAATI accreditations for a language "(.*)" to "(.*)"$/, function (from, to) {
+    let accreditationLanguagesServiceLink = $(contractorEngagementPage.accreditationFromToLanguagesServiceLinkLocator.replace("<dynamic1>",from).replace("<dynamic2>",to));
+    action.isVisibleWait(accreditationLanguagesServiceLink,10000);
+    action.clickElement(accreditationLanguagesServiceLink);
+    action.isClickableWait(contractorEngagementPage.validateButton, 10000);
+    action.clickElement(contractorEngagementPage.validateButton);
+    action.isExistingWait(contractorEngagementPage.naatiCertificationsFirstText,10000)
+    let actualCertificationsCount = contractorEngagementPage.naatiCertificationsText.length;
+    action.clickElement(contractorEngagementPage.cancelButtonOnNaatiAcceditationPopup);
+    chai.expect(actualCertificationsCount).to.equal(1);
+})
+
+Then(/^on Contractor Details History page, the NAATI accreditation "(.*)" will have been allocated to the interpreter’s profile$/, function (expectedNaatiAccreditation) {
+    action.isVisibleWait(contractorEngagementPage.viewHistoryButton, 10000);
+    action.clickElement(contractorEngagementPage.viewHistoryButton);
+    action.isVisibleWait(contractorEngagementPage.showContractAuditTrialsLink, 10000);
+    action.clickElement(contractorEngagementPage.showContractAuditTrialsLink);
+    action.waitForElementExist(contractorEngagementPage.auditHistoryNoItemsToShowMessage, 20000, true, "No items to show message is displayed after 20s", 500);
+    let actualAuditHistoryBody = action.getElementText(contractorEngagementPage.auditHistoryTableBody);
+    chai.expect(actualAuditHistoryBody).to.includes(expectedNaatiAccreditation);
+})


### PR DESCRIPTION
- Fixed 3 failed scenarios in Bookings feature file.
- Updated contractor engagement scenarios to delete blockers added to a contractor.
- Added new locators in Contractor engagement page for naati acceditation and history sections.
- Added reusable step methods to Add Naati Accreditation if not available, to verify Interpreter has one active NAATI accreditation, to verify the NAATI accreditation allocated to interpreter’s profile.
- Automated scenario 1b from LL-666 ticket.