### PR TITLE
Automated scenarios from LL-716 and LL-43  tickets

### DIFF
--- a/test/features/AccountManagement/AccountManagement.feature
+++ b/test/features/AccountManagement/AccountManagement.feature
@@ -143,3 +143,59 @@ Feature: Account Management features
     Examples:
       | username        | password | role filter option | user account   | firstName | lastName | birthDay   | officeLocation       | landLineNumber | mobileNumber | expectedData                                       |
       | TestA@gmail.com | Test1    | Contract Manager   | Britney Spears | Britney   | Spears   | 01-01-1996 | Test office location | 03 9875 4612   | 12 3456 7890 | 1st January 1996,Test office location,12 3456 7890 |
+
+    #LL-43 Scenario 1 - Edit email address
+  @EditEmailAddress @LL-43
+  Scenario Outline: Edit email address
+    When I login with "<username>" and "<password>"
+    And they will see the Accounts section displayed
+    And The user has selected an option "<role filter option>" from the Role filter dropdown
+    And The user has clicked the search button
+    And they click onto a user "<user account>" who belongs to the Client Group
+    And they are taken to the Account Profile page
+    And they will only see the Client Group roles
+    And the user clicks on the edit icon next to the email address
+    Then the user will be taken to the edit email pop up where they can change the email address
+
+    Examples:
+      | username        | password | role filter option | user account   |
+      | TestA@gmail.com | Test1    | Contract Manager   | Britney Spears |
+
+    #LL-43 Scenario 6 - User tries to enter email which already exists
+  @EnteredEmailAlreadyExists @LL-43
+  Scenario Outline: User tries to enter email which already exists
+    When I login with "<username>" and "<password>"
+    And they will see the Accounts section displayed
+    And The user has selected an option "<role filter option>" from the Role filter dropdown
+    And The user has clicked the search button
+    And they click onto a user "<user account>" who belongs to the Client Group
+    And they are taken to the Account Profile page
+    And the user clicks on the edit icon next to the email address
+    And the user will be taken to the edit email pop up where they can change the email address
+    And has entered a new email address "<emailAddress>","<emailAddress>"
+    And the user presses ‘Change Email’ button
+    Then a message ‘Email address already exist.’ appears
+
+    Examples:
+      | username          | password  | role filter option | user account   | emailAddress                |
+      | LLAdmin@looped.in | Octopus@6 | Contract Manager   | Britney Spears | britneyspears@police.gov.au |
+
+    #LL-43 Scenario 7 - User edits the email and click on Cancel icon in the popup
+  @EditEmailAndCancel @LL-43
+  Scenario Outline: User edits the email and click on Cancel icon in the popup
+    When I login with "<username>" and "<password>"
+    And they will see the Accounts section displayed
+    And The user has selected an option "<role filter option>" from the Role filter dropdown
+    And The user has clicked the search button
+    And they click onto a user "<user account>" who belongs to the Client Group
+    And they are taken to the Account Profile page
+    And the user clicks on the edit icon next to the email address
+    And the user will be taken to the edit email pop up where they can change the email address
+    And has entered a new email address "<emailAddress>","<emailAddress>"
+    And the user clicks 'X' icon
+    Then the email address "<emailAddress>" should not be updated
+
+
+    Examples:
+      | username          | password  | role filter option | user account   | emailAddress             |
+      | LLAdmin@looped.in | Octopus@6 | Contract Manager   | Britney Spears | testEmail1@police.gov.au |

--- a/test/features/BookingManagement/Bookings.feature
+++ b/test/features/BookingManagement/Bookings.feature
@@ -883,3 +883,21 @@ Feature: Create new booking for Interpreters
     Examples:
       | username          | password  | campus id | campus PinBillToCode | contractor | service     | from      | to      | level        | billTo          | severityLevel | jobTypes      | startDate  | endDate    | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | not eligible status | eligible status   |
       | LLAdmin@looped.in | Octopus@6 | 33124     |  33124 - DH006       | Automation | Interpreter | zz-Zenq2  | ENGLISH | Professional | DH006 - DH RDNS | 1             | Pre-booked TI | 05-02-2023 | 06-02-2023 | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Not eligible        | Auto Notification |
+
+    #LL-716 Expand the label on the client new job request screen
+    # In the ‘Instructions for Interpreters’, the user sees the following text as Label
+    #Instructions for Interpreter (Please DO NOT include interpreter’s name or personal details)
+  @CreateJobRequest @InstructionsForInterpreterLabel @LL-716
+  Scenario Outline: User sees the Instructions for Interpreters text as Label
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And I select "<dropdownfilter>" from the filter dropdown
+    And I click on new job request button
+    And I enter campus pin "<campus pin>"
+    And I select "<Requester Name>" from the requester name dropdown
+    And I click next button
+    Then in the ‘Instructions for Interpreters’, the user sees the text "<Instructions for Interpreters label>" as Label
+
+    Examples:
+      | username       | password | dropdownfilter | campus pin | Requester Name    | Instructions for Interpreters label                                                         |
+      | zenq@cso10.com | Test1    | Management     | 33124      | Automation Tester | Instructions for Interpreter (Please DO NOT include interpreter’s name or personal details) |

--- a/test/pages/Booking/JobRequestPage.js
+++ b/test/pages/Booking/JobRequestPage.js
@@ -364,4 +364,8 @@ module.exports={
     get organisationCampusBlocksContractorText() {
         return $('//span[text()="1. Organisation/Campus blocks Contractor"]');
     },
+
+    get instructionsForInterpreterLabelText() {
+        return $('//div[contains(text(),"Instructions for Interpreter")]');
+    }
 }

--- a/test/pages/Home/AdminPage.js
+++ b/test/pages/Home/AdminPage.js
@@ -243,5 +243,33 @@ module.exports = {
 
     get cancelButtonEditProfile() {
         return $('//input[@value="Cancel" and (contains(@id,"Actions"))]')
-    }
+    },
+
+    get editIconNextToEmailAddress() {
+        return $('//a[contains(@id,"MainContent_UserManagement_") and not(contains(@id,"Email"))]');
+    },
+
+    get changeEmailPopup() {
+        return $('//span[text()="Confirm Change of Email"]/parent::div/parent::div');
+    },
+
+    get newEmailTextBoxOnPopup() {
+        return $('//input[contains(@id,"NewEmail")]');
+    },
+
+    get confirmEmailTextBoxOnPopup() {
+        return $('//input[contains(@id,"ConfirmEmail")]');
+    },
+
+    get changeEmailButton() {
+        return $('//input[@value="Change email"]');
+    },
+
+    get emailAddressAlreadyExistsMessage() {
+        return $('//span[text()="Email address already exist."]');
+    },
+
+    get changeEmailPopupCloseButton() {
+        return $('//a[contains(@id,"ChangeEmailDialog_block_wtlbtnAltusDialogClose")]');
+    },
 }

--- a/test/stepdefinition/AccountManagement/AccountManagementSteps.js
+++ b/test/stepdefinition/AccountManagement/AccountManagementSteps.js
@@ -189,3 +189,40 @@ Then(/^the data "(.*)" will be not saved$/, function (expectedData) {
         chai.expect(savedDataDisplayStatus).to.be.false;
     }
 })
+
+When(/^the user clicks on the edit icon next to the email address$/, function () {
+    action.isVisibleWait(adminPage.editIconNextToEmailAddress,10000);
+    action.clickElement(adminPage.editIconNextToEmailAddress);
+})
+
+Then(/^the user will be taken to the edit email pop up where they can change the email address$/, function () {
+    let emailPopupDisplayStatus = action.isVisibleWait(adminPage.changeEmailPopup,10000);
+    chai.expect(emailPopupDisplayStatus).to.be.true;
+})
+
+When(/^has entered a new email address "(.*)","(.*)"$/, function (newEmail, confirmEmail) {
+    action.isVisibleWait(adminPage.newEmailTextBoxOnPopup, 10000);
+    action.enterValue(adminPage.newEmailTextBoxOnPopup, newEmail);
+    action.enterValue(adminPage.confirmEmailTextBoxOnPopup, confirmEmail);
+})
+
+When(/^the user presses ‘Change Email’ button$/, function () {
+    action.isVisibleWait(adminPage.changeEmailButton, 10000);
+    action.clickElement(adminPage.changeEmailButton);
+})
+
+Then(/^a message ‘Email address already exist.’ appears$/, function () {
+    let emailExistsDisplayStatus = action.isVisibleWait(adminPage.emailAddressAlreadyExistsMessage, 10000);
+    chai.expect(emailExistsDisplayStatus).to.be.true;
+})
+
+When(/^the user clicks 'X' icon$/, function () {
+    action.isVisibleWait(adminPage.changeEmailPopupCloseButton, 10000);
+    action.clickElement(adminPage.changeEmailPopupCloseButton);
+})
+
+Then(/^the email address "(.*)" should not be updated$/, function (emailAddress) {
+    let savedDataTextElement = $(adminPage.savedTextOnProfileDynamicLocator.replace("<dynamic>", emailAddress))
+    let savedDataDisplayStatus = action.isVisibleWait(savedDataTextElement, 1000);
+    chai.expect(savedDataDisplayStatus).to.be.false;
+})

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -559,3 +559,9 @@ When(/^the contractor above "(.*)" status will be "(.*)" for the Job$/,function(
     chai.expect(contractorJobStatusTextActual).to.equal("- No status -");
   }
 })
+
+Then(/^in the ‘Instructions for Interpreters’, the user sees the text "(.*)" as Label$/, function (expectedLabel) {
+  action.isVisibleWait(jobRequestPage.instructionsForInterpreterLabelText, 10000);
+  let instructionsLabelActual = action.getElementText(jobRequestPage.instructionsForInterpreterLabelText);
+  chai.expect(instructionsLabelActual).to.equal(expectedLabel);
+})


### PR DESCRIPTION
- Added new locators in Admin page and Job request page.
- Added reusable step methods to verify the Instructions for Interpreters label text, to click and edit email address on profile, to change email, to verify Email address already exists, to cancel and verify email not updated.
- Automated scenario 1 from LL-716 ticket.
- Automated scenario 1, scenario 6 and scenario 7 from LL-43 ticket.