### PR TITLE
Automated scenarios from LL-447 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsCBO.feature
+++ b/test/features/ODTI/ODTIJobsCBO.feature
@@ -284,7 +284,7 @@ Feature: ODTI Jobs CBO features
 
     Examples:
       | username cbo   | password cbo | campus id                                                      | start date | end date   | records count |
-      | zenq@cbo11.com | Test1        | 29449 Contoso Pty LTD LYSTERFIELD DRIVE ROXBURGH PARK VIC 3064 | 01-03-2022 | 24-01-2023 | 500           |
+      | zenq@cbo11.com | Test1        | 29449 Contoso Pty LTD LYSTERFIELD DRIVE ROXBURGH PARK VIC 3064 | 01-03-2022 | 10-03-2023 | 500           |
 
     #Scenario 13 - Verifying the records exported to excel when the records are less than 500 for the selected filters
   @Regression @RegressionS13 @CBOLessThan500RecordsExportExcel

--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -268,3 +268,50 @@ Feature: ODTI Jobs CSO features
     Examples:
       | username cso   | password cso |
       | zenq@cso10.com | Test1        |
+
+    #LL-447 Scenario 3 - CS user views ODTI Interpreters page
+  @LL-447 @CSUserViewsInterpretersPage
+  Scenario Outline: CS user views ODTI Interpreters page
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    Then they will see the ODTI Interpreters page by default
+    And they will see a dropdown to switch to the ODTI Jobs page
+    And they will see a dropdown to select Language
+    And they will a dropdown to select Logon Status with label Any - LogOn Status
+
+    Examples:
+      | username cso   | password cso |
+      | zenq@cso10.com | Test1        |
+
+    #LL-447 Scenario 4 - CS user views Language search
+  @LL-447 @CSUserViewsLanguageSearch
+  Scenario Outline: CS user views Language search
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    Then they will see a language searchable dropdown
+    And the label will be: Language
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select a single Language "<language>"
+
+    Examples:
+      | username cso   | password cso | language |
+      | zenq@cso10.com | Test1        | CHINESE  |
+
+    #LL-447 Scenario 4a - CS user views “Any-LogOn Status” search
+  @LL-447 @CSUserViewsLogOnStatusSearch
+  Scenario Outline: CS user views Any-LogOn Status search
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    Then they will a dropdown to select Logon Status with label Any - LogOn Status
+    And the label will be: Any-LogOn Status
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select status for the selected language using options "<logon status options>"
+
+    Examples:
+      | username cso   | password cso | language | logon status options          |
+      | zenq@cso10.com | Test1        | CHINESE  | Any - LogOn Status,True,False |

--- a/test/pages/ODTI/ODTIJobsPage.js
+++ b/test/pages/ODTI/ODTIJobsPage.js
@@ -167,5 +167,41 @@ module.exports = {
 
     get filterCloseXIcon() {
         return $('//span[@class="fa fa-fw fa-close"]/parent::a');
-    }
+    },
+
+    get ODTIJobsSwitchDropdown() {
+        return $('//select[contains(@class,"BorderlessShadowlessDropdown")]');
+    },
+
+    get ODTIJobsSwitchDropdownOptionLocator() {
+        return '//select[contains(@class,"BorderlessShadowlessDropdown")]/option[text()="<dynamic>"]';
+    },
+
+    get ODTILanguageSwitchDropdown() {
+        return $('//div[contains(@id,"Language")]');
+    },
+
+    get ODTILanguageDropdownLabel() {
+        return '//span[text()="<dynamic>"]';
+    },
+
+    get ODTILogonStatusDropdown() {
+        return $('//select[contains(@id,"LogOn")]');
+    },
+
+    get ODTILogonStatusDropdownLabel() {
+        return $('//select[contains(@id,"LogOn")]/Option[text()="Any - LogOn Status"]');
+    },
+
+    get ODTILanguageSwitchDropdown() {
+        return $('//span[text()="- Language -"]');
+    },
+
+    get languageDropdownSearchBox() {
+        return $('//input[contains(@id,"s2id_autogen1_search")]')
+    },
+
+    get logonStatusDropdownOptionLabel() {
+        return '//select[contains(@id,"LogOn")]/option[text()="<dynamic>"]';
+    },
 }

--- a/test/stepdefinition/Home/AdminSteps.js
+++ b/test/stepdefinition/Home/AdminSteps.js
@@ -215,6 +215,7 @@ When(/^Clicks Create Account$/, function () {
 
 When(/^Selects any role "(.*)"$/, function (role) {
    let roleToggleElement = $(adminPage.roleToggleLocator.replace("<dynamic>", role));
+   action.isVisibleWait(roleToggleElement, 10000);
    action.isClickableWait(roleToggleElement, 10000);
    action.clickElement(roleToggleElement);
 })
@@ -474,6 +475,7 @@ When(/^select multiple roles "(.*)"$/, function (roles) {
    let rolesList = roles.split(",");
    for (let index = 0; index < rolesList.length; index++) {
       let roleToggleElement = $(adminPage.roleToggleLocator.replace("<dynamic>", rolesList[index]));
+      action.isVisibleWait(roleToggleElement, 10000);
       action.isClickableWait(roleToggleElement, 10000);
       action.clickElement(roleToggleElement);
    }

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -444,3 +444,69 @@ When(/^they are navigated to the ODTI page$/, function () {
     let pageTitleActual = action.getPageTitle()
     chai.expect(pageTitleActual).to.includes("ODTI");
 })
+
+Then(/^they will see the ODTI Interpreters page by default$/, function () {
+    let ODTIInterpretersPageOption = $(ODTIJobsPage.ODTIJobsSwitchDropdownOptionLocator.replace("<dynamic>", "ODTI Interpreters"));
+    let InterpretersPageSelectedStatus = action.isSelectedWait(ODTIInterpretersPageOption, 10000);
+    chai.expect(InterpretersPageSelectedStatus).to.be.true;
+})
+
+Then(/^they will see a dropdown to switch to the ODTI Jobs page$/, function () {
+    let ODTIJobsSwitchDropdownDisplayStatus = action.isVisibleWait(ODTIJobsPage.ODTIJobsSwitchDropdown, 10000);
+    chai.expect(ODTIJobsSwitchDropdownDisplayStatus).to.be.true;
+})
+
+Then(/^they will see a dropdown to select Language$/, function () {
+    let ODTILanguageSwitchDropdownDisplayStatus = action.isVisibleWait(ODTIJobsPage.ODTILanguageSwitchDropdown, 10000);
+    chai.expect(ODTILanguageSwitchDropdownDisplayStatus).to.be.true;
+})
+
+Then(/^they will a dropdown to select Logon Status with label Any - LogOn Status$/, function () {
+    let ODTILogonStatusDisplayStatus = action.isVisibleWait(ODTIJobsPage.ODTILogonStatusDropdown, 10000);
+    chai.expect(ODTILogonStatusDisplayStatus).to.be.true;
+    let ODTILogonStatusDropdownLabelDisplayStatus = action.isVisibleWait(ODTIJobsPage.ODTILogonStatusDropdownLabel, 10000);
+    chai.expect(ODTILogonStatusDropdownLabelDisplayStatus).to.be.true;
+})
+
+Then(/^they will see a language searchable dropdown$/, function () {
+    action.isVisibleWait(ODTIJobsPage.ODTILanguageSwitchDropdown, 10000);
+    action.clickElement(ODTIJobsPage.ODTILanguageSwitchDropdown);
+    let languageDropdownSearchBoxDisplayStatus = action.isVisibleWait(ODTIJobsPage.languageDropdownSearchBox, 10000);
+    chai.expect(languageDropdownSearchBoxDisplayStatus).to.be.true;
+})
+
+Then(/^the label will be: Language$/, function () {
+    let languageDropdownLanguageLabelElement = $(ODTIJobsPage.ODTILanguageDropdownLabel.replace("<dynamic>", "- Language -"));
+    let languageDropdownLabelDisplayStatus = action.isVisibleWait(languageDropdownLanguageLabelElement, 10000);
+    chai.expect(languageDropdownLabelDisplayStatus).to.be.true;
+})
+
+Then(/^the user will be able to search for a language "(.*)"$/, function (language) {
+    if (action.isVisibleWait(ODTIJobsPage.languageDropdownSearchBox, 10000) === false) {
+        action.clickElement(ODTIJobsPage.ODTILanguageSwitchDropdown);
+    }
+    action.enterValueAndPressReturn(ODTIJobsPage.languageDropdownSearchBox, language);
+})
+
+Then(/^the user will be able to select a single Language "(.*)"$/, function (language) {
+    let languageSelectedElement = $(ODTIJobsPage.ODTILanguageDropdownLabel.replace("<dynamic>", language));
+    let languageSelectedDisplayStatus = action.isVisibleWait(languageSelectedElement, 10000);
+    chai.expect(languageSelectedDisplayStatus).to.be.true;
+})
+
+Then(/^the label will be: Any-LogOn Status$/, function () {
+    let logonStatusDropdownLabelElement = $(ODTIJobsPage.logonStatusDropdownOptionLabel.replace("<dynamic>", "Any - LogOn Status"));
+    let logonStatusDropdownLabelSelectedStatus = action.isSelectedWait(logonStatusDropdownLabelElement, 10000);
+    chai.expect(logonStatusDropdownLabelSelectedStatus).to.be.true;
+})
+
+Then(/^the user will be able to select status for the selected language using options "(.*)"$/, function (logonStatus) {
+    action.isVisibleWait(ODTIJobsPage.ODTILogonStatusDropdown);
+    let logonStatusListOptions = logonStatus.split(",");
+    for (let index = 0; index < logonStatusListOptions.length; index++) {
+        action.selectTextFromDropdown(ODTIJobsPage.ODTILogonStatusDropdown, logonStatusListOptions[index]);
+        let logonStatusDropdownLabelElement = $(ODTIJobsPage.logonStatusDropdownOptionLabel.replace("<dynamic>", logonStatusListOptions[index]));
+        let logonStatusDropdownLabelSelectedStatus = action.isSelectedWait(logonStatusDropdownLabelElement, 10000);
+        chai.expect(logonStatusDropdownLabelSelectedStatus).to.be.true;
+    }
+})

--- a/test/utils/actions.js
+++ b/test/utils/actions.js
@@ -316,5 +316,11 @@ module.exports={
         let elementAttributeValue = elt.getAttribute(attributeName)
         return elementAttributeValue;
     },
+
+    getPageTitle() {
+        let pageTitle = browser.getTitle();
+        console.log("Page Title is: "+pageTitle);
+        return pageTitle;
+    },
 }
 


### PR DESCRIPTION
- Fixed failed test cases by adding get page title method and updating examples data, re-executed the failed scenarios and found all tests passed.
- Added new locators in ODTI Jobs page.
- Added reusable step methods to verify ODTI Interpreters page, dropdowns to select Jobs page, language, logon status, labels and to search and select languages and logon status.
- Automated scenario 3, scenario 4 and scenario 4a from LL-447 ticket.