### PR TITLE
Automated scenarios 5a, 5b, 6a and 6b from LL-447 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -315,3 +315,69 @@ Feature: ODTI Jobs CSO features
     Examples:
       | username cso   | password cso | language | logon status options          |
       | zenq@cso10.com | Test1        | CHINESE  | Any - LogOn Status,True,False |
+
+    #LL-447 Scenario 5a - CS user selects language
+  @LL-447 @CSUserSelectsLanguage
+  Scenario Outline: CS user views Language search
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And they will see a language searchable dropdown
+    And the label will be: Language
+    And the user will be able to search for a language "<language>"
+    Then the table will appear
+    And show only interpreters "<interpreters>" with that Language
+
+    Examples:
+      | username cso   | password cso | language | interpreters                                          |
+      | zenq@cso10.com | Test1        | CHINESE  | Bowen (Bella) LYU,Lai Wan LEUNG,Lucia Yee Fong CHEUNG |
+
+  #LL-447 Scenario 5b - CS user selects 'Any-LogOn Status'.
+  @LL-447 @CSUserSelectsAnyLogOnStatus
+  Scenario Outline: CS user selects Any-LogOn Status
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select status for the selected language using options "<logon status option>"
+    Then the table will appear
+    And show only interpreters with selected Language and the LogOn Status "<logon status column>" containing "<logon status results>" status
+
+    Examples:
+      | username cso   | password cso | language | logon status option | logon status column | logon status results |
+      | zenq@cso10.com | Test1        | Zenq3    | Any - LogOn Status  |   6                 | True,False           |
+
+    #LL-447 Scenario 6a - CS user views table
+  @LL-447 @CSUserViewsTable
+  Scenario Outline: CS user views table
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select status for the selected language using options "<logon status option>"
+    Then the table will appear
+    And the table will have the following columns: "<column headers>"
+    And the data will be displayed under each column as per the mockup
+    And Name will be hyperlinked to the Contractor profile
+
+    Examples:
+      | username cso   | password cso | language | logon status option | column headers                                                                                                     |
+      | zenq@cso10.com | Test1        | Zenq3    | Any - LogOn Status  | CONTRACTOR ID,NAME,NAATI LEVEL,GENDER,PHONE,LOGON STATUS,ATTEMPTS,ON CALL,CURRENT BOOKING START/END,JOB/CONTACT ID |
+
+    #LL-447 Scenario Scenario 6b - NAATI level shown for current language
+  @LL-447 @NAATILevelShownForLanguage
+  Scenario Outline: NAATI level shown for current language
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And the user will be able to search for a language "<language>"
+    And the table will have the following columns: "<column headers>"
+    Then it will show the NAATI Level for that Language or Contractor
+
+    Examples:
+      | username cso   | password cso | language | column headers |
+      | zenq@cso10.com | Test1        | CHINESE  | NAATI LEVEL    |

--- a/test/pages/ODTI/ODTIJobsPage.js
+++ b/test/pages/ODTI/ODTIJobsPage.js
@@ -204,4 +204,28 @@ module.exports = {
     get logonStatusDropdownOptionLabel() {
         return '//select[contains(@id,"LogOn")]/option[text()="<dynamic>"]';
     },
+
+    get ODTIInterpretersResultsTable() {
+        return $('//table[contains(@id,"ContractorODTITable")]');
+    },
+
+    get ODTIInterpretersResultsTableBody() {
+        return $('//table[contains(@id,"ContractorODTITable")]/tbody');
+    },
+
+    get interpreterResultRowsCount(){
+        return $$('//table[contains(@id,"ContractorODTITable")]/tbody/tr').length;
+    },
+
+    get interpreterResultsValueLocator(){
+        return '//table[contains(@id,"ContractorODTITable")]/tbody/tr[<dynamicRowNumber>]/td[<dynamicColumnNumber>]';
+    },
+
+    get interpreterColumnHeaders(){
+        return $('//table[contains(@id,"ContractorODTITable")]/thead/tr');
+    },
+
+    get interpreterColumnHeaders(){
+        return $('//table[contains(@id,"ContractorODTITable")]/thead/tr');
+    },
 }

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -510,3 +510,56 @@ Then(/^the user will be able to select status for the selected language using op
         chai.expect(logonStatusDropdownLabelSelectedStatus).to.be.true;
     }
 })
+
+Then(/^the table will appear$/, function () {
+    let ODTIInterpretersResultsTableDisplayStatus = action.isVisibleWait(ODTIJobsPage.ODTIInterpretersResultsTable,10000);
+    chai.expect(ODTIInterpretersResultsTableDisplayStatus).to.be.true;
+})
+
+Then(/^show only interpreters "(.*)" with that Language$/, function (interpreters) {
+    let interpretersList = interpreters.split(",");
+    let ODTIInterpretersResultsTableTextActual = action.getElementText(ODTIJobsPage.ODTIInterpretersResultsTableBody);
+    for (let index = 0; index < interpretersList.length; index++) {
+        chai.expect(ODTIInterpretersResultsTableTextActual).to.includes(interpretersList[index]);
+    }
+})
+
+Then(/^show only interpreters with selected Language and the LogOn Status "(.*)" containing "(.*)" status$/, function (columnNumber,logonStatus) {
+    browser.pause(5000);
+    let logonStatusList = logonStatus.split(",");
+    let logonStatusActual = [];
+    let totalRowsCount = ODTIJobsPage.interpreterResultRowsCount;
+    for (let row = 1; row <= totalRowsCount; row++) {
+        let columnValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", row.toString()).replace("<dynamicColumnNumber>", columnNumber.toString()));
+        let actualColumnValue = action.getElementText(columnValueElement);
+        logonStatusActual.push(actualColumnValue);
+    }
+    chai.expect(logonStatusActual).to.include.members(logonStatusList);
+})
+
+Then(/^the table will have the following columns: "(.*)"$/, function (expectedColumns) {
+    let columnsList = expectedColumns.split(",");
+    let ODTIInterpretersTableColumnsActual = action.getElementText(ODTIJobsPage.interpreterColumnHeaders);
+    for (let index = 0; index < columnsList.length; index++) {
+        chai.expect(ODTIInterpretersTableColumnsActual).to.includes(columnsList[index]);
+    }
+})
+
+Then(/^the data will be displayed under each column as per the mockup$/, function () {
+    let ODTITableDataDisplayStatus = action.isVisibleWait(ODTIJobsPage.ODTIInterpretersResultsTableBody,10000);
+    chai.expect(ODTITableDataDisplayStatus).to.be.true;
+})
+
+Then(/^Name will be hyperlinked to the Contractor profile$/, function () {
+    let columnValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", "1").replace("<dynamicColumnNumber>", "2"));
+    let actualContractorNameHTML = action.getElementHTML(columnValueElement);
+    chai.expect(actualContractorNameHTML).to.includes("<a ");
+    chai.expect(actualContractorNameHTML).to.includes("href");
+})
+
+Then(/^it will show the NAATI Level for that Language or Contractor$/, function () {
+    let interpreterNAATILevels = ["Conference (Senior)","Conference","Certified Interpreter","Professional","Certified Provisional Interpreter","Recognised","Non-Accredited"];
+    let columnValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", "1").replace("<dynamicColumnNumber>", "3"));
+    let actualNAATIText = action.getElementText(columnValueElement);
+    chai.expect(interpreterNAATILevels).to.include(actualNAATIText);
+})

--- a/test/utils/actions.js
+++ b/test/utils/actions.js
@@ -322,5 +322,10 @@ module.exports={
         console.log("Page Title is: "+pageTitle);
         return pageTitle;
     },
+
+    getElementHTML(elt){
+        let elementHTML = elt.getHTML()
+        return elementHTML;
+    },
 }
 


### PR DESCRIPTION
- Added new locators in ODTI Jobs page and added action method to get element HTML.
- Added reusable step methods to verify the ODTI interpreters table, table shows interpreters with selected language and LogOn Status, table columns, data displayed under columns, Name hyperlinked and NAATI Level.
- Automated scenario 5a, scenario 5b, scenario 6a and scenario 6b from LL-447 ticket.