### PR TITLE
Automated Scenario 6e, 6f and 7 from LL-447 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -444,8 +444,8 @@ Feature: ODTI Jobs CSO features
     And the table will not show cancelled jobs for the interpreter "<contractor>"
 
     Examples:
-      | username          | password  | contractor | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | original status                 | new status | username cso   | password cso | logon status option |
-      | LLAdmin@looped.in | Octopus@6 | Automation | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Fullday         | current date | 09:30 | hh@bb.com.au | Auto Notification,- No status - | Allocated  | zenq@cso10.com | Test1        | Any - LogOn Status  |
+      | username          | password  | contractor | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | original status                 | new status | username cso   | password cso | logon status option | service     | from      | to      | level        |
+      | LLAdmin@looped.in | Octopus@6 | Automation | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Fullday         | current date | 09:30 | hh@bb.com.au | Auto Notification,- No status - | Allocated  | zenq@cso10.com | Test1        | Any - LogOn Status  | Interpreter | zz-Zenq2  | ENGLISH | Professional |
 
     #LL-447Scenario 6d - Table shows next pre-booked job.
   #GIVEN the CS user is looking at the table

--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -505,3 +505,49 @@ Feature: ODTI Jobs CSO features
     Examples:
       | username          | password  | contractor | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date                   | time  | email        | original status                 | new status | username cso   | password cso | logon status option | service     | from      | to      | level        |
       | LLAdmin@looped.in | Octopus@6 | Automation | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Fullday         | within fifteen minutes | 09:30 | hh@bb.com.au | Auto Notification,- No status - | Allocated  | zenq@cso10.com | Test1        | Any - LogOn Status  | Interpreter | zz-Zenq2  | ENGLISH | Professional |
+
+    #LL-447 Scenario 6e - Table shows empty Job ID and Start/End Time
+  @LL-447 @TableShowsEmptyJobIdAndTime
+  Scenario Outline: Table shows empty Job ID and Start/End Time
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select status for the selected language using options "<logon status option>"
+    Then if the Job ID has no data, then the Start End time also has no data
+
+    Examples:
+      | username cso   | password cso | language | logon status option |
+      | zenq@cso10.com | Test1        | zz-Zenq2 | Any - LogOn Status  |
+
+    #LL-447 Scenario 6f - Table shows filled Job ID and Start/End Time
+  @LL-447 @TableShowsFilledJobIdAndTime
+  Scenario Outline: Table shows filled Job ID and Start/End Time
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select status for the selected language using options "<logon status option>"
+    Then if the Job ID has data, then the Start End time also has data
+
+    Examples:
+      | username cso   | password cso | language | logon status option |
+      | zenq@cso10.com | Test1        | zz-Zenq2 | Any - LogOn Status  |
+
+    #LL-447 Scenario 7 - CS user clicks contractor name
+  @LL-447 @CSUserClicksContractorName
+  Scenario Outline: CS user clicks contractor name
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select status for the selected language using options "<logon status option>"
+    And they click on the hyperlinked Contractor name
+    Then they are navigated to the Contractor Profile and this will open in a new browser tab
+
+    Examples:
+      | username cso   | password cso | language | logon status option |
+      | zenq@cso10.com | Test1        | zz-Zenq2 | Any - LogOn Status  |

--- a/test/pages/ODTI/ODTIJobsPage.js
+++ b/test/pages/ODTI/ODTIJobsPage.js
@@ -213,23 +213,27 @@ module.exports = {
         return $('//table[contains(@id,"ContractorODTITable")]/tbody');
     },
 
-    get interpreterResultRowsCount(){
+    get interpreterResultRowsCount() {
         return $$('//table[contains(@id,"ContractorODTITable")]/tbody/tr').length;
     },
 
-    get interpreterResultsValueLocator(){
+    get interpreterResultsValueLocator() {
         return '//table[contains(@id,"ContractorODTITable")]/tbody/tr[<dynamicRowNumber>]/td[<dynamicColumnNumber>]';
     },
 
-    get interpreterColumnHeaders(){
+    get interpreterColumnHeaders() {
         return $('//table[contains(@id,"ContractorODTITable")]/thead/tr');
     },
 
-    get interpreterColumnHeaders(){
+    get interpreterColumnHeaders() {
         return $('//table[contains(@id,"ContractorODTITable")]/thead/tr');
     },
 
-    get interpreterResultsLinkTextValueLocator(){
+    get interpreterResultsLinkTextValueLocator() {
         return '//table[contains(@id,"ContractorODTITable")]/tbody//span[contains(text(),"<dynamicRowLinkText>")]/parent::a/parent::td/parent::tr/td[<dynamicColumnNumber>]'
+    },
+
+    get interpreterResultsValueLinkLocator() {
+        return '//table[contains(@id,"ContractorODTITable")]/tbody/tr[<dynamicRowNumber>]/td[<dynamicColumnNumber>]/a';
     },
 }

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -518,6 +518,7 @@ Then(/^the table will appear$/, function () {
 })
 
 Then(/^show only interpreters "(.*)" with that Language$/, function (interpreters) {
+    browser.pause(5000);
     let interpretersList = interpreters.split(",");
     let ODTIInterpretersResultsTableTextActual = action.getElementText(ODTIJobsPage.ODTIInterpretersResultsTableBody);
     for (let index = 0; index < interpretersList.length; index++) {
@@ -552,6 +553,7 @@ Then(/^the data will be displayed under each column as per the mockup$/, functio
 })
 
 Then(/^Name will be hyperlinked to the Contractor profile$/, function () {
+    browser.pause(5000);
     let columnValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", "1").replace("<dynamicColumnNumber>", "2"));
     let actualContractorNameHTML = action.getElementHTML(columnValueElement);
     chai.expect(actualContractorNameHTML).to.includes("<a ");
@@ -559,6 +561,7 @@ Then(/^Name will be hyperlinked to the Contractor profile$/, function () {
 })
 
 Then(/^it will show the NAATI Level for that Language or Contractor$/, function () {
+    browser.pause(5000);
     let interpreterNAATILevels = ["Conference (Senior)","Conference","Certified Interpreter","Professional","Certified Provisional Interpreter","Recognised","Non-Accredited"];
     let columnValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", "1").replace("<dynamicColumnNumber>", "3"));
     let actualNAATIText = action.getElementText(columnValueElement);
@@ -566,24 +569,28 @@ Then(/^it will show the NAATI Level for that Language or Contractor$/, function 
 })
 
 Then(/^the table will show the current ongoing job for the interpreter "(.*)"$/, function (interpreter) {
+    browser.pause(5000);
     let columnValueElement = $(ODTIJobsPage.interpreterResultsLinkTextValueLocator.replace("<dynamicRowLinkText>", interpreter).replace("<dynamicColumnNumber>", "10"));
     let actualJobID = action.getElementText(columnValueElement);
     chai.expect(actualJobID).to.equal(GlobalData.CURRENT_JOB_ID.toString());
 })
 
 Then(/^the table will not show cancelled jobs for the interpreter "(.*)"$/, function (interpreter) {
+    browser.pause(5000);
     let columnValueElement = $(ODTIJobsPage.interpreterResultsLinkTextValueLocator.replace("<dynamicRowLinkText>", interpreter).replace("<dynamicColumnNumber>", "10"));
     let actualJobID = action.getElementText(columnValueElement);
     chai.expect(actualJobID).to.not.equal(GlobalData.CURRENT_JOB_ID.toString());
 })
 
 Then(/^the table will also show the next pre-booked job for the interpreter "(.*)"$/, function (interpreter) {
+    browser.pause(5000);
     let columnValueElement = $(ODTIJobsPage.interpreterResultsLinkTextValueLocator.replace("<dynamicRowLinkText>", interpreter).replace("<dynamicColumnNumber>", "10"));
     let actualJobID = action.getElementText(columnValueElement);
     chai.expect(actualJobID).to.equal(GlobalData.CURRENT_JOB_ID.toString());
 })
 
 Then(/^this will be the next pre-booked job with a start time within the next 15 minutes for the interpreter "(.*)"$/, function (interpreter) {
+    browser.pause(5000);
     let columnValueElement = $(ODTIJobsPage.interpreterResultsLinkTextValueLocator.replace("<dynamicRowLinkText>", interpreter).replace("<dynamicColumnNumber>", "9"));
     let bookingTimeActual = action.getElementText(columnValueElement);
     bookingTimeActual = bookingTimeActual.split(" - ")[0].toString();
@@ -592,4 +599,48 @@ Then(/^this will be the next pre-booked job with a start time within the next 15
     let withInFifteenMinutesTime = temp_date_time[1];
     let jobTimeIsWithinNext15Minutes = datetime.compareTimeValues(bookingTime24HoursActual, withInFifteenMinutesTime);
     chai.expect(jobTimeIsWithinNext15Minutes).to.be.true;
+})
+
+Then(/^if the Job ID has no data, then the Start End time also has no data$/, function () {
+    browser.pause(5000);
+    let totalRowsCount = ODTIJobsPage.interpreterResultRowsCount;
+    for (let row = 1; row <= totalRowsCount; row++) {
+        let jobIdValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", row.toString()).replace("<dynamicColumnNumber>", "10"));
+        let bookingTimeValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", row.toString()).replace("<dynamicColumnNumber>", "9"));
+        let jobIdText = action.getElementText(jobIdValueElement);
+        let bookingTimeText = action.getElementText(bookingTimeValueElement);
+        if (jobIdText === "") {
+            chai.expect(bookingTimeText).to.equal("");
+        }
+    }
+})
+
+Then(/^if the Job ID has data, then the Start End time also has data$/, function () {
+    browser.pause(5000);
+    let totalRowsCount = ODTIJobsPage.interpreterResultRowsCount;
+    for (let row = 1; row <= totalRowsCount; row++) {
+        let jobIdValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", row.toString()).replace("<dynamicColumnNumber>", "10"));
+        let bookingTimeValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", row.toString()).replace("<dynamicColumnNumber>", "9"));
+        let jobIdText = action.getElementText(jobIdValueElement);
+        let bookingTimeText = action.getElementText(bookingTimeValueElement);
+        if (jobIdText !== "") {
+            chai.expect(bookingTimeText).to.not.equal("");
+        }
+    }
+})
+
+When(/^they click on the hyperlinked Contractor name$/, function () {
+    browser.pause(5000);
+    let actualContractorNameElement = $(ODTIJobsPage.interpreterResultsValueLinkLocator.replace("<dynamicRowNumber>", "1").replace("<dynamicColumnNumber>", "2"));
+    GlobalData.CONTRACTOR_NAME = action.getElementText(actualContractorNameElement).toLowerCase();
+    action.clickElement(actualContractorNameElement);
+})
+
+When(/^they are navigated to the Contractor Profile and this will open in a new browser tab$/, function () {
+    action.navigateToLatestWindow();
+    action.isVisibleWait(ODTIJobsPage.selectedInterpreterNameText, 10000);
+    let currentInterpreterPageUrl = action.getPageUrl();
+    chai.expect(currentInterpreterPageUrl).to.includes("ManagementModules/PreviewContractorProfile.aspx");
+    let contractorNameInProfile = action.getElementText(ODTIJobsPage.selectedInterpreterNameText).toLowerCase();
+    chai.expect(contractorNameInProfile).to.includes(GlobalData.ODTI_INTERPRETER_NAME);
 })


### PR DESCRIPTION
- Fixed examples data in Scenario 6c from LL-447 ticket.
- Added new locators in ODTI Jobs page.
- Added reusable step methods to verify ODTI interpreters table ID and Start End time both have data or no data, click on the hyperlinked Contractor name and verify navigation to profile happens in new browser window.
- Automated Scenario 6e, Scenario 6f and Scenario 7 from LL-447 ticket.