### PR TITLE
Automated Scenario 9 and 10 from LL-447 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -551,3 +551,32 @@ Feature: ODTI Jobs CSO features
     Examples:
       | username cso   | password cso | language | logon status option |
       | zenq@cso10.com | Test1        | zz-Zenq2 | Any - LogOn Status  |
+
+    #LL-447 Scenario 9 - CS user do not select ‘Language' and 'Any-LogOn Status'.
+  @LL-447 @CSUserDoNotSelectLanguageAndLogOnStatus
+  Scenario Outline: CS user do not select Language and Any-LogOn Status
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    Then no results will be displayed in the table
+    And show the text as 'No items to show...’
+
+    Examples:
+      | username cso   | password cso |
+      | zenq@cso10.com | Test1        |
+
+    #LL-447 Scenario 10 - CS performs sorting on each column.
+  @LL-447 @CSUserPerformsSortODTIInterpreters
+  Scenario Outline: CS performs sorting on each column.
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And they are navigated to the ODTI page
+    And they will see the ODTI Interpreters page by default
+    And the user will be able to search for a language "<language>"
+    And the user will be able to select status for the selected language using options "<logon status option>"
+    Then the columns are sorted correctly when I click on each column which are sortable "<column headers>"
+
+    Examples:
+      | username cso   | password cso | language | logon status option | column headers                                                                                                     |
+      | zenq@cso10.com | Test1        | zz-Zenq2 | Any - LogOn Status  | Contractor ID,Name,NAATI Level,Gender,Empty,Logon Status,Attempts,On Call,CURRENT BOOKING Start/End,Job/Contact ID |

--- a/test/pages/ODTI/ODTIJobsPage.js
+++ b/test/pages/ODTI/ODTIJobsPage.js
@@ -236,4 +236,12 @@ module.exports = {
     get interpreterResultsValueLinkLocator() {
         return '//table[contains(@id,"ContractorODTITable")]/tbody/tr[<dynamicRowNumber>]/td[<dynamicColumnNumber>]/a';
     },
+
+    get ODTIInterpretersResultsEmptyTable() {
+        return $('//table[contains(@id,"ContractorODTITable") and contains(@class,"Empty")]');
+    },
+
+    get noItemsToShowText() {
+        return $('//td[text()="No items to show..."]');
+    }
 }

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -642,5 +642,5 @@ When(/^they are navigated to the Contractor Profile and this will open in a new 
     let currentInterpreterPageUrl = action.getPageUrl();
     chai.expect(currentInterpreterPageUrl).to.includes("ManagementModules/PreviewContractorProfile.aspx");
     let contractorNameInProfile = action.getElementText(ODTIJobsPage.selectedInterpreterNameText).toLowerCase();
-    chai.expect(contractorNameInProfile).to.includes(GlobalData.ODTI_INTERPRETER_NAME);
+    chai.expect(contractorNameInProfile).to.includes(GlobalData.CONTRACTOR_NAME);
 })

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -644,3 +644,53 @@ When(/^they are navigated to the Contractor Profile and this will open in a new 
     let contractorNameInProfile = action.getElementText(ODTIJobsPage.selectedInterpreterNameText).toLowerCase();
     chai.expect(contractorNameInProfile).to.includes(GlobalData.CONTRACTOR_NAME);
 })
+
+Then(/^no results will be displayed in the table$/, function () {
+    let ODTIInterpretersResultsEmptyTableDisplayStatus = action.isVisibleWait(ODTIJobsPage.ODTIInterpretersResultsEmptyTable, 10000);
+    chai.expect(ODTIInterpretersResultsEmptyTableDisplayStatus).to.be.true;
+})
+
+Then(/^show the text as 'No items to show...’$/, function () {
+    let noItemsToShowTextDisplayStatus = action.isVisibleWait(ODTIJobsPage.noItemsToShowText, 1000);
+    chai.expect(noItemsToShowTextDisplayStatus).to.be.true;
+})
+
+Then(/^the columns are sorted correctly when I click on each column which are sortable "(.*)"$/, function (columnHeaders) {
+    let columnHeadersList = columnHeaders.split(",");
+    for (let header = 0; header < columnHeadersList.length; header++) {
+        let valuesActual = [];
+        let valuesSorted = [];
+        let timeMeridiemValues = [];
+        let columnHeaderElement = $(ODTIJobsPage.columnHeaderLocator.replace("<dynamic>", columnHeadersList[header]))
+        if (columnHeadersList[header] !== "Empty") {
+            action.clickElement(columnHeaderElement);
+            browser.pause(3000);
+            let totalRowsCount = ODTIJobsPage.interpreterResultRowsCount;
+            for (let row = 1; row <= totalRowsCount; row++) {
+                let headerIndex = header + 1;
+                let columnValueElement = $(ODTIJobsPage.interpreterResultsValueLocator.replace("<dynamicRowNumber>", row.toString()).replace("<dynamicColumnNumber>", headerIndex.toString()));
+                if (action.isExistingWait(columnValueElement, 0)) {
+                    valuesActual.push(action.getElementText(columnValueElement));
+                }
+            }
+            if (valuesActual[valuesActual.length - 1].includes(":")) {
+                for (let i = 0; i < valuesActual.length; i++) {
+                    let timeValueActual = valuesActual[i].split(" ")[1];
+                    if (timeValueActual === "AM" || timeValueActual === "PM") {
+                        timeMeridiemValues.push(timeValueActual);
+                    }
+                }
+                valuesActual = timeMeridiemValues;
+                valuesSorted = [...valuesActual].sort();
+            } else if (valuesActual[1].includes("$")) {
+                valuesActual = valuesActual.map(function (element) {
+                    return element.replace(/\$/g, "");
+                });
+                valuesSorted = [...valuesActual].sort((a, b) => a - b);
+            } else {
+                valuesSorted = [...valuesActual].sort();
+            }
+            chai.expect(valuesActual).to.have.ordered.members(valuesSorted);
+        }
+    }
+})


### PR DESCRIPTION
- Fixed 1 failed scenario by updating the assertion code, re-executed and found all tests passed.
- Added new locators in ODTI Jobs page.
- Added reusable step methods to verify no results displayed in ODTI interpreters table, 'No items to show...' text and the columns are sorted correctly when clicked on each column which are sortable.
- Automated Scenario 9 and Scenario 10 from LL-447 ticket.