### PR TITLE
Automated Scenario 2 and 5 from LL-659 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -302,9 +302,45 @@ Feature: ODTI Jobs CSO features
     And I click on a Job ID value under ODTI SERVICE CHARGE ID column
     And the user is viewing the Job Details page
     And the user is viewing the allocated interpreter section
-    And  they click on the Contractor Name
+    And they click on the Contractor Name
     Then they will be navigated to the Contractor’s profile
 
     Examples:
       | username cso   | password cso |
       | zenq@cso10.com | Test1        |
+
+    #LL-659 Scenario 2 - CS / Finance user sees Job Info section
+  @LL-659 @CSUserSeesJobInfoSection
+  Scenario Outline: CS / Finance user sees Job Info section
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And I view the ODTI > ODTI Jobs page
+    And I get Campus Name value under Campus Name column
+    And I click on a Job ID value under ODTI SERVICE CHARGE ID column
+    And the user is viewing the Job Details page
+    Then they will see a heading with the Job ID number and the Campus Name as per existing functionality
+    And they will see the following details and information in the Job Info section: "<JobInfoSectionName>", "<JobInfoSectionLabels>"
+    And they will see the following details and information in the Job Info section: "<additionalInfoSectionName>", "<additionalInfoSectionLabels>"
+    And they will see the following details and information in the Job Info section: "<customFieldsSectionName>", "<customFieldsSectionLabels>"
+
+    Examples:
+      | username cso   | password cso | JobInfoSectionName | JobInfoSectionLabels                                                                                                                                                                           | additionalInfoSectionName | additionalInfoSectionLabels                                                                                                                                                        | customFieldsSectionName | customFieldsSectionLabels |
+      | zenq@cso10.com | Test1        | Job Information    | DID,Job Reference Number,Service Type,Campus PIN,Client Call ID,Contractor ID,Gender Preference,Language,Call Start Date/Time,Interpreter Connect Date/Time,Interpreter End Date/Time,Duration | Additional Information    | Job Status,DID Timezone,Client AH / BH,Public holiday,CX1 Contact ID,Operator called,MIL Phone Number,UI capture screen used,Is 5 min rule,Contract Name,NES Details,Record Status | Custom Fields           | [EX1] Reference number    |
+
+    #LL-659 Scenario 5 - CS / Finance user sees Allocated Interpreter section
+  @LL-659 @CSSeesAllocatedInterpreterSection
+  Scenario Outline: CS / Finance user sees Allocated Interpreter section
+    When I login with "<username cso>" and "<password cso>"
+    And I click ODTI header link
+    And I view the ODTI > ODTI Jobs page
+    And I click on a Job ID value under ODTI SERVICE CHARGE ID column
+    And the user is viewing the Job Details page
+    Then they will see the Allocated Interpreter section under the Job Info section as per existing functionality for Job Bookings
+    And this will show 1 contractor that was connected to the call
+    And the job allocation table will show the following: "<labelsDisplayed>"
+    And the job allocation table will not show the following: "<labelsNotDisplayed>"
+    And  the Contractor’s name will be hyperlinked
+
+    Examples:
+      | username cso   | password cso | labelsDisplayed                                                   | labelsNotDisplayed                 |
+      | zenq@cso10.com | Test1        | CONTRACTOR,PHONE,NAATI LEVEL,TIMES CONNECTED,DURATION,AFTER HOURS | DISTANCE,GENDER,PROBABILITY,STATUS |

--- a/test/pages/Booking/JobDetailsPage.js
+++ b/test/pages/Booking/JobDetailsPage.js
@@ -173,4 +173,16 @@ module.exports = {
         return $('//div[@class="JobAllocationContainer"]');
     },
 
+    get jobInfoSectionLabelsDynamicLocator() {
+        return '//span[text()="<dynamicSectionName>"]/parent::div//child::span[text()="<dynamicLabel>"]';
+    },
+
+    get jobAllocationSectionUnderJobInfoSection() {
+        return $('//div[contains(@id,"DetailsContainer")]//div[@class="JobAllocationContainer"]');
+    },
+
+    get jobAllocationTableHeaders() {
+        return $('//table[contains(@id,"ODTIServiceChargeTable")]/thead/tr');
+    }
+
 }

--- a/test/stepdefinition/Booking/JobDetailsSteps.js
+++ b/test/stepdefinition/Booking/JobDetailsSteps.js
@@ -204,3 +204,46 @@ Then(/^they click on the Contractor Name$/, function () {
     action.isVisibleWait(contractNameHyperLink,10000);
     action.clickElement(contractNameHyperLink);
 })
+
+Then(/^they will see a heading with the Job ID number and the Campus Name as per existing functionality$/, function () {
+    let jobIDAndCampusNameValueInJobDetails = action.getElementText(jobDetailsPage.jobIdLabel);
+    chai.expect(jobIDAndCampusNameValueInJobDetails).to.includes(GlobalData.ODTI_SERVICE_CHARGE_JOB_ID_IN_TABLE);
+    chai.expect(jobIDAndCampusNameValueInJobDetails).to.includes(GlobalData.ODTI_CAMPUS_NAME);
+})
+
+Then(/^they will see the following details and information in the Job Info section: "(.*)", "(.*)"$/, function (sectionName, labels) {
+    let labelsList = labels.split(",");
+    for (let index = 0; index < labelsList.length; index++) {
+        let jobInfoSectionLabelElement = $(jobDetailsPage.jobInfoSectionLabelsDynamicLocator.replace("<dynamicSectionName>", sectionName).replace("<dynamicLabel>", labelsList[index]));
+        let jobInfoLabelDisplayStatus = action.isVisibleWait(jobInfoSectionLabelElement, 10000);
+        chai.expect(jobInfoLabelDisplayStatus).to.be.true;
+    }
+})
+Then(/^they will see the Allocated Interpreter section under the Job Info section as per existing functionality for Job Bookings$/, function () {
+    let jobAllocationSectionUnderJobInfoDisplayStatus = action.isVisibleWait(jobDetailsPage.jobAllocationSectionUnderJobInfoSection,10000);
+    chai.expect(jobAllocationSectionUnderJobInfoDisplayStatus).to.be.true;
+})
+
+Then(/^the job allocation table will show the following: "(.*)"$/, function (expectedHeaders) {
+    let expectedHeadersList = expectedHeaders.split(",")
+    action.isVisibleWait(jobDetailsPage.jobAllocationTableHeaders, 10000);
+    let jobAllocationTableHeadersActual = action.getElementText(jobDetailsPage.jobAllocationTableHeaders);
+    for (let index = 0; index < expectedHeadersList.length; index++) {
+        chai.expect(jobAllocationTableHeadersActual).to.includes(expectedHeadersList[index]);
+    }
+})
+
+Then(/^the job allocation table will not show the following: "(.*)"$/, function (expectedHeaders) {
+    let expectedHeadersList = expectedHeaders.split(",")
+    action.isVisibleWait(jobDetailsPage.jobAllocationTableHeaders, 10000);
+    let jobAllocationTableHeadersActual = action.getElementText(jobDetailsPage.jobAllocationTableHeaders);
+    for (let index = 0; index < expectedHeadersList.length; index++) {
+        chai.expect(jobAllocationTableHeadersActual).to.not.includes(expectedHeadersList[index]);
+    }
+})
+
+Then(/^the Contractor’s name will be hyperlinked$/, function () {
+    let contractNameHyperLink = $(jobDetailsPage.jobAllocationDynamicValueLinkLocator.replace("<dynamicRowNumber>", "1").replace("<dynamicColumnNumber>", "1"));
+    let contractNameHyperLinkDisplayStatus = action.isVisibleWait(contractNameHyperLink,10000);
+    chai.expect(contractNameHyperLinkDisplayStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in Job details page.
- Added reusable step methods to verify heading with the Job ID number and the Campus Name, labels in Job Info section, Allocated Interpreter section and labels displayed and not displayed in job allocation.
- Automated Scenario 2 and Scenario 5 from LL-659 ticket.