### PR TITLE
Automated Scenarios from LL-627 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsFinance.feature
+++ b/test/features/ODTI/ODTIJobsFinance.feature
@@ -77,3 +77,21 @@ Feature: ODTI Jobs Finance features
     Examples:
       | username              | password | column headers                                                                                                                                         |
       | testauto@finance1.com | Test1    | ODTI SERVICE CHARGE ID,CALL START,CALL DURATION,CAMPUS NAME,LANGUAGE,INTERPRETER NAME,CALL TYPE,CLIENT CHARGE SUBTOTAL,INTERPRETER CHARGE TOTAL EX GST |
+
+    #LL-627 Scenario 6 - CS / Finance user clicks a hyperlink
+  @LL-627 @FinanceClicksHyperlink
+  Scenario Outline: CS / Finance user clicks a hyperlink
+    When I login with "<username>" and "<password>"
+    And I click ODTI header link
+    And I view the ODTI > ODTI Jobs page
+    And they will see a table
+    And they click the ODTI Service Charge ID hyperlink
+    Then they are navigated to the Job Details page in a new tab
+    And they click the Campus Name hyperlink
+    And they are navigated to the Campus Details page in a new tab
+    And they click the Interpreter Name
+    And they are navigated to the Interpreter’s Profile page in a new tab
+
+    Examples:
+      | username              | password |
+      | testauto@finance1.com | Test1    |

--- a/test/pages/Interpreting/InterpretingPage.js
+++ b/test/pages/Interpreting/InterpretingPage.js
@@ -90,6 +90,22 @@ module.exports={
     get messageForInterpreterOKButton()
     {
         return $('//*[contains(text(),"Message for Interpreters")]/../..//input[@type="submit"]')
+    },
+
+    get jobFilterFieldDropdownOptionLocator() {
+        return '(//select[contains(@id,"Field")])[<dynamicIndex>]/child::option[text()="<dynamicOption>"]';
+    },
+
+    get jobFilterValueTextBoxLocator() {
+        return '(//input[contains(@id,"ListAdvanceSearchRule")])[<dynamicIndex>]';
+    },
+
+    get jobTableRowsCount() {
+        return $$('//div[contains(@id,"JobTable")]/table[contains(@id,"JobTable")]/tbody/tr').length;
+    },
+
+    get jobTableDynamicTextValueLocator() {
+        return '//div[contains(@id,"JobTable")]/table[contains(@id,"JobTable")]/tbody/tr[<dynamicRowIndex>]/td[<dynamicColumnIndex>]'
     }
 
 }

--- a/test/stepdefinition/Interpreting/InterpretingSteps.js
+++ b/test/stepdefinition/Interpreting/InterpretingSteps.js
@@ -151,3 +151,17 @@ console.log("Scenario name :"+scenarioName)
     // success case, the file was saved
 });
 })
+
+When(/^a user has accessed the Bookings "(.*)" screen$/, function (listItem) {
+  action.isVisibleWait(interpretingPage.filterDropdown, 20000);
+  action.selectTextFromDropdown(interpretingPage.filterDropdown, listItem);
+})
+
+When(/^the URL contains the CampusPIN parameter "(.*)"$/, function (campusPin) {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/Bookings.aspx?CampusPIN=" + campusPin);
+})
+
+Then(/^the Bookings Allocations screen will display$/, function () {
+  let pageTitleActual = action.getPageTitle();
+  chai.expect(pageTitleActual).to.includes("Bookings");
+})

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -512,3 +512,41 @@ Then(/^the user will not see the "(.*)" column$/, function (expectedHeaders) {
         chai.expect(odtiColumnHeadersActual).to.not.includes(headerListExpected[headerIndex]);
     }
 })
+
+When(/^they click the ODTI Service Charge ID hyperlink$/, function () {
+    let serviceChargeID1TextElement = $(ODTIJobsPage.odtiTableResultsHyperlinkDataElementLocator.replace("<dynamicColumnIndex>", "1"));
+    action.isVisibleWait(serviceChargeID1TextElement, 10000);
+    action.clickElement(serviceChargeID1TextElement);
+})
+
+When(/^they are navigated to the Job Details page in a new tab$/, function () {
+    action.navigateToLatestWindow();
+    let currentPageUrlActual = action.getPageUrl();
+    chai.expect(currentPageUrlActual).to.includes("JobDetails.aspx");
+})
+
+When(/^they click the Campus Name hyperlink$/, function () {
+    action.navigateToWindowHandle(GlobalData.ODTI_JOBS_PAGE_WINDOW_HANDLE)
+    let campusName1TextElement = $(ODTIJobsPage.odtiTableResultsHyperlinkDataElementLocator.replace("<dynamicColumnIndex>", "4"));
+    action.isVisibleWait(campusName1TextElement, 10000);
+    action.clickElement(campusName1TextElement);
+})
+
+When(/^they are navigated to the Campus Details page in a new tab$/, function () {
+    action.navigateToLatestWindow();
+    let currentPageUrlActual = action.getPageUrl();
+    chai.expect(currentPageUrlActual).to.includes("CampusDetails.aspx");
+})
+
+When(/^they click the Interpreter Name$/, function () {
+    action.navigateToWindowHandle(GlobalData.ODTI_JOBS_PAGE_WINDOW_HANDLE)
+    let interpreterName1TextElement = $(ODTIJobsPage.odtiTableResultsHyperlinkDataElementLocator.replace("<dynamicColumnIndex>", "6"));
+    action.isVisibleWait(interpreterName1TextElement, 10000);
+    action.clickElement(interpreterName1TextElement);
+})
+
+When(/^they are navigated to the Interpreter’s Profile page in a new tab$/, function () {
+    action.navigateToLatestWindow();
+    let currentPageUrlActual = action.getPageUrl();
+    chai.expect(currentPageUrlActual).to.includes("PreviewContractorProfile.aspx");
+})

--- a/test/utils/actions.js
+++ b/test/utils/actions.js
@@ -385,5 +385,23 @@ module.exports={
         console.log("Fetched window handle: "+windowHandle);
         return windowHandle;
     },
+
+    /**
+     * The Switch To Window command is used to select the current top-level browsing context for the current session, i.e. the one that will be used for processing commands.
+     * @param windowHandle
+     */
+    navigateToWindowHandle(windowHandle) {
+        browser.pause(2000);
+        browser.switchToWindow(windowHandle);
+        console.log("Switched to window: "+windowHandle);
+    },
+
+    /**
+     * Protocol binding to load the URL of the browser. If a baseUrl is specified in the config, it will be prepended to the url parameter using node's url.resolve() method.
+     * @returns {string}
+     */
+    launchURL(URL) {
+        browser.url(URL);
+    },
 }
 


### PR DESCRIPTION
- Added new locators in Interpreting Bookings page.
- Added reusable action methods to switch to a window handle and to launch a URL in browser window.
- Added reusable step methods to verify page navigations in a new tab upon clicking ODTI Service Charge ID,  Campus Name and Interpreter Name hyperlinks, to access the Bookings screen, to set URL with the CampusPIN parameter and to verify Bookings Allocations screen is displayed.
- Automated Scenario 6 from LL-627 ticket.