### PR TITLE
Automated Scenario 1 and Scenario 2 from LL-636 ticket

### DIFF
--- a/test/features/BookingManagement/BookingsAllocations.feature
+++ b/test/features/BookingManagement/BookingsAllocations.feature
@@ -1,0 +1,36 @@
+@BookingsAllocations
+Feature: Bookings Allocations Features
+
+  Background: Load Loopedin login page
+    Given the looped in login page is opened
+
+
+    #LL-636 Scenario 1: Campus PIN in URL
+  @LL-636 @CampusPINInURL
+  Scenario Outline: Campus PIN in URL
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And a user has accessed the Bookings "<allocations>" screen
+    And the URL contains the CampusPIN parameter "<campusPIN>"
+    Then the Bookings Allocations screen will display
+    And a CampusPIN filter should be pre-filled with the given CampusPIN "<campusPIN>"
+    And the rest of the form should display as if the user has filtered by Campus PIN "<campusName>"
+
+    Examples:
+      | username        | password  | allocations | campusPIN | campusName      |
+      | zenq2@ll.com.au | Reset@312 | Allocations | 29449     | Contoso Pty LTD |
+
+    #LL-636 Scenario 2: Contractor ID in URL
+  @LL-636 @ContractorIDInURL
+  Scenario Outline: Contractor ID in URL
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And a user has accessed the Bookings "<allocations>" screen
+    And the URL contains the ContractorID parameter "<contractorID>"
+    Then the Bookings Allocations screen will display
+    And a ContractorID filter should be pre-filled with the given ContractorID "<contractorID>"
+    And the rest of the form should display as if the user has filtered by ContractorID "<interpreterName>"
+
+    Examples:
+      | username        | password  | allocations | contractorID | interpreterName |
+      | zenq2@ll.com.au | Reset@312 | Allocations | 6155         | Adel ODISH      |

--- a/test/stepdefinition/Home/AdminSteps.js
+++ b/test/stepdefinition/Home/AdminSteps.js
@@ -218,6 +218,15 @@ When(/^Selects any role "(.*)"$/, function (role) {
    action.isVisibleWait(roleToggleElement, 10000);
    action.isClickableWait(roleToggleElement, 10000);
    action.clickElement(roleToggleElement);
+   browser.pause(1000);
+   let roleToggleStatusElement = $(adminPage.roleToggleStatusLocator.replace("<dynamic>", role));
+   let toggleElementClassActual = action.getElementAttribute(roleToggleStatusElement,"class");
+   let counter = 0;
+   while (toggleElementClassActual.includes("changed") === false && counter < 3) {
+      action.clickElement(roleToggleElement);
+      toggleElementClassActual = action.getElementAttribute(roleToggleStatusElement);
+      counter++;
+   }
 })
 
 Given(/^Fills out all the required details "(.*)", email, "(.*) in Admin Page"$/, function (firstName, landLineNumber) {

--- a/test/stepdefinition/Interpreting/InterpretingSteps.js
+++ b/test/stepdefinition/Interpreting/InterpretingSteps.js
@@ -165,3 +165,45 @@ Then(/^the Bookings Allocations screen will display$/, function () {
   let pageTitleActual = action.getPageTitle();
   chai.expect(pageTitleActual).to.includes("Bookings");
 })
+
+Then(/^a CampusPIN filter should be pre-filled with the given CampusPIN "(.*)"$/, function (campusPin) {
+  let campusPinElement = $(interpretingPage.jobFilterFieldDropdownOptionLocator.replace("<dynamicIndex>","1").replace("<dynamicOption>","Campus PIN"));
+  let campusPinFilterSelectedStatus = action.isSelectedWait(campusPinElement,20000);
+  chai.expect(campusPinFilterSelectedStatus).to.be.true;
+  let campusPinValuePreFilledElement = $(interpretingPage.jobFilterValueTextBoxLocator.replace("<dynamicIndex>","1"));
+  let campusPinValuePreFilled = action.getElementValue(campusPinValuePreFilledElement);
+  chai.expect(campusPinValuePreFilled).to.equal(campusPin);
+})
+
+Then(/the rest of the form should display as if the user has filtered by Campus PIN "(.*)"$/, function (campusName) {
+  browser.pause(5000);
+  let jobRowsCount = interpretingPage.jobTableRowsCount;
+  for (let rowIndex = 1; rowIndex <= jobRowsCount; rowIndex++) {
+    let campusNameTextElement = $(interpretingPage.jobTableDynamicTextValueLocator.replace("<dynamicRowIndex>",rowIndex.toString()).replace("<dynamicColumnIndex>","6"));
+    let actualCampusNameText = action.getElementText(campusNameTextElement);
+    chai.expect(actualCampusNameText).to.equal(campusName);
+  }
+})
+
+When(/^the URL contains the ContractorID parameter "(.*)"$/, function (contractorID) {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/Bookings.aspx?ContractorId=" + contractorID);
+})
+
+Then(/^a ContractorID filter should be pre-filled with the given ContractorID "(.*)"$/, function (contractorID) {
+  let contractorIDElement = $(interpretingPage.jobFilterFieldDropdownOptionLocator.replace("<dynamicIndex>","1").replace("<dynamicOption>","Contractor ID"));
+  let contractorIDFilterSelectedStatus = action.isSelectedWait(contractorIDElement,20000);
+  chai.expect(contractorIDFilterSelectedStatus).to.be.true;
+  let contractorIDValuePreFilledElement = $(interpretingPage.jobFilterValueTextBoxLocator.replace("<dynamicIndex>","1"));
+  let contractorIDValuePreFilled = action.getElementValue(contractorIDValuePreFilledElement);
+  chai.expect(contractorIDValuePreFilled).to.equal(contractorID);
+})
+
+Then(/the rest of the form should display as if the user has filtered by ContractorID "(.*)"$/, function (interpreterName) {
+  browser.pause(5000);
+  let jobRowsCount = interpretingPage.jobTableRowsCount;
+  for (let rowIndex = 1; rowIndex <= jobRowsCount; rowIndex++) {
+    let interpreterNameTextElement = $(interpretingPage.jobTableDynamicTextValueLocator.replace("<dynamicRowIndex>",rowIndex.toString()).replace("<dynamicColumnIndex>","9"));
+    let actualInterpreterNameText = action.getElementText(interpreterNameTextElement);
+    chai.expect(actualInterpreterNameText).to.equal(interpreterName);
+  }
+})


### PR DESCRIPTION
- Updated account role toggle method to fix synchronization issue, re-executed the failed scenario and found all tests passed.
- Added reusable step methods to verify CampusPIN, ContractorID filters pre-filled with the given CampusPIN, ContractorID, to verify form should display as filtered by Campus PIN, ContractorID and to set the URL with the ContractorID parameter.
- Automated Scenario 1 and Scenario 2 from LL-636 ticket.