### PR TITLE
Automated Scenario 6, 7 and 8 from LL-636 ticket

### DIFF
--- a/test/features/BookingManagement/BookingsAllocations.feature
+++ b/test/features/BookingManagement/BookingsAllocations.feature
@@ -79,3 +79,44 @@ Feature: Bookings Allocations Features
     Examples:
       | username        | password  | allocations | contractorID |
       | zenq2@ll.com.au | Reset@312 | Allocations | 5667         |
+
+    #LL-636  Scenario 6: Entering Contractor ID in the URL that does not exists
+  @LL-636 @ContractorIDInURLThatDoesNotExist @LL-6361
+  Scenario Outline: Entering Contractor ID in the URL that does not exists
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And a user has accessed the Bookings "<allocations>" screen
+    And the URL contains the ContractorID parameter "<contractorID>"
+    Then the Bookings Allocations screen will display
+    And a ContractorID filter should be pre-filled with the given ContractorID "<contractorID>"
+    And the results should not be displayed as there are no jobs to show
+
+    Examples:
+      | username        | password  | allocations | contractorID |
+      | zenq2@ll.com.au | Reset@312 | Allocations | 5            |
+
+    #LL-636 Scenario 7: As Client - Campus PIN filter should not be added on entering Campus pin in the URL
+  @LL-636 @AsClientCampusPINInURL @LL-6361
+  Scenario Outline: Campus PIN in URL
+    When I login with "<username cbo>" and "<password cbo>"
+    And I click Interpreting header link
+    And enter the Campus pin "<campusPIN>" that is Active in the URL
+    Then the Bookings Allocations screen will display
+    And a CampusPIN filter should not be displayed and pre filled with the given Campus PIN "<campusPIN>"
+
+    Examples:
+      | username cbo   | password cbo | campusPIN |
+      | zenq@cbo11.com | Test1        | 29449     |
+
+    #LL-636 Scenario 8: As Client - Contractor ID filter should not be added on entering Contractor ID in the URL
+  @LL-636 @AsClientContractorIDInURL @LL-6361
+  Scenario Outline: Contractor ID in URL
+    When I login with "<username cbo>" and "<password cbo>"
+    And I click Interpreting header link
+    And enter the ContractorID "<contractorID>" that is Active in the URL
+    Then the Bookings Allocations screen will display
+    And a Contractor ID filter should not be displayed and pre filled with the given Contractor ID "<contractorID>"
+
+    Examples:
+      | username cbo   | password cbo | contractorID |
+      | zenq@cbo11.com | Test1        | 6155         |

--- a/test/stepdefinition/Home/AdminSteps.js
+++ b/test/stepdefinition/Home/AdminSteps.js
@@ -224,7 +224,7 @@ When(/^Selects any role "(.*)"$/, function (role) {
    let counter = 0;
    while (toggleElementClassActual.includes("changed") === false && counter < 3) {
       action.clickElement(roleToggleElement);
-      toggleElementClassActual = action.getElementAttribute(roleToggleStatusElement);
+      toggleElementClassActual = action.getElementAttribute(roleToggleStatusElement, "class");
       counter++;
    }
 })
@@ -493,7 +493,7 @@ When(/^select multiple roles "(.*)"$/, function (roles) {
       let counter = 0;
       while (toggleElementClassActual.includes("changed") === false && counter < 3) {
          action.clickElement(roleToggleElement);
-         toggleElementClassActual = action.getElementAttribute(roleToggleStatusElement);
+         toggleElementClassActual = action.getElementAttribute(roleToggleStatusElement,"class");
          counter++;
       }
    }

--- a/test/stepdefinition/Interpreting/InterpretingSteps.js
+++ b/test/stepdefinition/Interpreting/InterpretingSteps.js
@@ -212,3 +212,39 @@ Then(/^the results should not be displayed as there are no jobs to show$/, funct
   let noJobsToShowMessageDisplayStatus = action.isVisibleWait(interpretingPage.jobTableNoJobsToShowMessage, 20000);
   chai.expect(noJobsToShowMessageDisplayStatus).to.be.true
 })
+
+When(/^enter the Campus pin "(.*)" that is Active in the URL$/, function (campusPin) {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/ClientBookings.aspx?CampusPIN=" + campusPin);
+})
+
+Then(/^a CampusPIN filter should not be displayed and pre filled with the given Campus PIN "(.*)"$/, function (campusPin) {
+  let campusPinElement = $(interpretingPage.jobFilterFieldDropdownOptionLocator.replace("<dynamicIndex>", "1").replace("<dynamicOption>", "Campus PIN"));
+  let campusPinFilterSelectedStatus = action.isSelectedWait(campusPinElement, 1000);
+  chai.expect(campusPinFilterSelectedStatus).to.be.false;
+  let campusPinValuePreFilledElement = $(interpretingPage.jobFilterValueTextBoxLocator.replace("<dynamicIndex>", "1"));
+  let campusPinValuePreFilledDisplayStatus = action.isVisibleWait(campusPinValuePreFilledElement, 1000);
+  if (campusPinValuePreFilledDisplayStatus === true) {
+    let campusPinValuePreFilled = action.getElementValue(campusPinValuePreFilledElement);
+    chai.expect(campusPinValuePreFilled).to.not.equal(campusPin);
+  } else {
+    chai.expect(campusPinValuePreFilledDisplayStatus).to.be.false;
+  }
+})
+
+When(/^enter the ContractorID "(.*)" that is Active in the URL$/, function (contractorID) {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/ClientBookings.aspx?ContractorId=" + contractorID);
+})
+
+Then(/^a Contractor ID filter should not be displayed and pre filled with the given Contractor ID "(.*)"$/, function (contractorID) {
+  let contractorIDElement = $(interpretingPage.jobFilterFieldDropdownOptionLocator.replace("<dynamicIndex>", "1").replace("<dynamicOption>", "Contractor ID"));
+  let contractorIDFilterSelectedStatus = action.isSelectedWait(contractorIDElement, 1000);
+  chai.expect(contractorIDFilterSelectedStatus).to.be.false;
+  let contractorIDValuePreFilledElement = $(interpretingPage.jobFilterValueTextBoxLocator.replace("<dynamicIndex>", "1"));
+  let contractorIDValuePreFilledDisplayStatus = action.isVisibleWait(contractorIDValuePreFilledElement, 1000);
+  if (contractorIDValuePreFilledDisplayStatus === true) {
+    let contractorIDValuePreFilled = action.getElementValue(contractorIDValuePreFilledElement);
+    chai.expect(contractorIDValuePreFilled).to.not.equal(contractorID);
+  } else {
+    chai.expect(contractorIDValuePreFilledDisplayStatus).to.be.false;
+  }
+})


### PR DESCRIPTION
- Fixed account role toggle method by performing click after checking element attribute, re-executed the failed scenario and found all tests passed.
- Added reusable step methods to enter the Campus pin, ContractorID which are active in URL, to verify as a Client user CampusPIN, ContractorID filters not displayed and pre filled with the given Campus PIN, ContractorID.
- Automated Scenario 6, Scenario 7 and Scenario 8 from LL-636 ticket.