### PR TITLE
Automated scenario 1a and 1b from LL-324 ticket

### DIFF
--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -473,3 +473,23 @@ Feature: Campus Management features
   Examples:
    | username          | password    | campus id | budget code option | budget code value |
    | LLAdmin@looped.in |  Octopus@6  | 33124     | Budget Code        | ANZ Bank          |
+
+  #LL-324 Scenario 1b: Admin sees ODTI gender preference option on Campus
+ @LL-324 @ODTIGenderPreferenceOnCampus
+ Scenario Outline: Admin sees ODTI gender preference option on Campus
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click Add preference button in Campus Details
+  And click the Preference Type dropdown in Campus Details
+  Then they will see an ODTI gender preference option with the label "<preference type option>" in Campus Details
+  And this option "<preference type option>" will appear under the Gender option in Campus Details
+  And they can select this option "<preference type option>" in Campus Details
+  And they select preference option "<preference>" in Campus Details
+  And they click save Contract Preference button in Campus Details
+  And they remove added preference type option "<preference type option>" in Campus Details
+
+  Examples:
+   | username          | password    | campus id | preference type option | preference |
+   | LLAdmin@looped.in |  Octopus@6  | 33124     | Gender (On-demand TI)  | Female     |

--- a/test/features/AccountManagement/ContractManagement.feature
+++ b/test/features/AccountManagement/ContractManagement.feature
@@ -258,11 +258,12 @@ Feature: Contract Management features
   And I search for campus "<campus id>"
   And I click the first campus link from search results
   And this preference "<preference>" is inherited by the Campus
+  And preference inherited from the Contract can be overridden "<override preference>" on the Campus level
   And I click account management link
   And I search for contract title "<contract title>"
   And I click the contract link "<contract title>" from search results
   And they remove added preference type option "<preference type option>" in Contract Details
 
   Examples:
-   | username          | password  | contract title                                   | preference type option | campus id | preference |
-   | LLAdmin@looped.in | Octopus@6 | Department of Health and Human Services - Health | Gender (On-demand TI)  | 33124     | Female     |
+   | username          | password  | contract title                                   | preference type option | campus id | preference | override preference |
+   | LLAdmin@looped.in | Octopus@6 | Department of Health and Human Services - Health | Gender (On-demand TI)  | 33124     | Female     | Preferred Female    |

--- a/test/pages/CampusDetails/CampusDetails.js
+++ b/test/pages/CampusDetails/CampusDetails.js
@@ -392,10 +392,18 @@ module.exports ={
     },
 
     get campusPreferenceTypeRemoveIconLocator() {
-        return '//span[text()="<dynamicOption>"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[@class="fa fa-fw fa-trash-o"]'
+        return '//span[text()="<dynamicOption>"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[@class="fa fa-fw fa-trash-o"]';
     },
 
     get saveCampusPreferenceButton() {
         return $('//input[contains(@id,"btnSavePreference")]');
+    },
+
+    get campusGenderODTIDropdown() {
+        return $('//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//select[contains(@id,"GenderPreference")]');
+    },
+
+    get campusGenderODTIDropdownOptionLocator() {
+        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//select[contains(@id,"GenderPreference")]/option[text()="<dynamicOption>"]';
     }
 }

--- a/test/pages/ContractManagement/ContractManagement.js
+++ b/test/pages/ContractManagement/ContractManagement.js
@@ -220,5 +220,9 @@ module.exports = {
 
     get saveContractPreferenceButton() {
         return $('//input[contains(@id,"btnSavePreference")]');
+    },
+
+    get contractGenderODTIPreferenceAdded() {
+        return $('//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]');
     }
 }

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -797,7 +797,7 @@ Then(/^this preference "(.*)" is inherited by the Campus$/, function (preference
     chai.expect(campusOptionSelectedStatus).to.be.true;
 })
 
-When(/^they click Add preference button in Campus Details$/, function (preference) {
+When(/^they click Add preference button in Campus Details$/, function () {
     action.isVisibleWait(campusDetailsPage.campusAddPreferenceLink, 10000);
     action.clickElement(campusDetailsPage.campusAddPreferenceLink);
 })
@@ -821,7 +821,7 @@ Then(/^this option "(.*)" will appear under the Gender option in Campus Details$
 
 Then(/^they can select this option "(.*)" in Campus Details$/, function (optionLabel) {
     action.selectTextFromDropdown(campusDetailsPage.campusPreferenceTypeDropdown, optionLabel);
-    let preferenceTypeDropdownOptionElement = $(campusDetailsPage.campusPreferenceTypeDropdown.replace("<dynamicOption>", optionLabel));
+    let preferenceTypeDropdownOptionElement = $(campusDetailsPage.campusPreferenceTypeDropdownOptionLocator.replace("<dynamicOption>", optionLabel));
     let optionSelectedStatus = action.isSelectedWait(preferenceTypeDropdownOptionElement, 10000);
     chai.expect(optionSelectedStatus).to.be.true;
 })
@@ -841,4 +841,12 @@ When(/^they remove added preference type option "(.*)" in Campus Details$/, func
 When(/^they click save Contract Preference button in Campus Details/, function () {
     action.isVisibleWait(campusDetailsPage.saveCampusPreferenceButton, 10000);
     action.clickElement(campusDetailsPage.saveCampusPreferenceButton);
+})
+
+When(/^preference inherited from the Contract can be overridden "(.*)" on the Campus level$/, function (option) {
+    action.isVisibleWait(campusDetailsPage.campusGenderODTIDropdown,20000);
+    action.selectTextFromDropdown(campusDetailsPage.campusGenderODTIDropdown, option);
+    let campusGenderODTIDropdownOptionLocatorElement = $(campusDetailsPage.campusGenderODTIDropdownOptionLocator.replace("<dynamicOption>", option));
+    let optionSelectedStatus = action.isSelectedWait(campusGenderODTIDropdownOptionLocatorElement, 10000);
+    chai.expect(optionSelectedStatus).to.be.true;
 })

--- a/test/stepdefinition/AccountManagement/ContractSteps.js
+++ b/test/stepdefinition/AccountManagement/ContractSteps.js
@@ -393,3 +393,8 @@ When(/^they click save Contract Preference button in Contract Details/, function
     action.isVisibleWait(contractManagementPage.saveContractPreferenceButton, 10000);
     action.clickElement(contractManagementPage.saveContractPreferenceButton);
 })
+
+When(/^related contract do not have Gender On-Demand TI preference added$/, function () {
+    let genderODTIPreferenceAddedDisplayStatus = action.isVisibleWait(contractManagementPage.contractGenderODTIPreferenceAdded, 1000);
+    chai.expect(genderODTIPreferenceAddedDisplayStatus).to.be.false;
+})


### PR DESCRIPTION
- Added new locators in Campus details page.
- Added reusable step methods to verify preference inherited from the Contract can be overridden on the Campus level and related contract do not have Gender On-Demand TI preference added.
- Automated scenario 1b from LL-324 ticket.
- Updated scenario 1a and started automating scenario 2 from LL-324 ticket.