### PR TITLE
Automated scenario 2 and 3 from LL-324 ticket 

### DIFF
--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -493,3 +493,60 @@ Feature: Campus Management features
   Examples:
    | username          | password    | campus id | preference type option | preference |
    | LLAdmin@looped.in |  Octopus@6  | 33124     | Gender (On-demand TI)  | Female     |
+
+  #LL-324 Scenario 2: Campus can still add their own Gender (On-Demand TI) even when Contract does not have any
+ @LL-324 @CampusAddOwnODTIGenderPreference
+ Scenario Outline: Campus can still add their own Gender (On-Demand TI) even when Contract does not have any
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for contract title "<contract title>"
+  And I click the contract link "<contract title>" from search results
+  And related contract do not have Gender On-Demand TI preference added
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click Add preference button in Campus Details
+  And click the Preference Type dropdown in Campus Details
+  Then they will see an ODTI gender preference option with the label "<preference type option>" in Campus Details
+  And this option "<preference type option>" will appear under the Gender option in Campus Details
+  And they can select this option "<preference type option>" in Campus Details
+  And they select preference option "<preference>" in Campus Details
+  And they click save Contract Preference button in Campus Details
+  And the preference is added for the Campus
+  And this preference "<preference type option>" will have delete icon as this created by campus
+  And they remove added preference type option "<preference type option>" in Campus Details
+
+  Examples:
+   | username          | password    | contract title                                   | campus id | preference type option | preference |
+   | LLAdmin@looped.in |  Octopus@6  | Department of Health and Human Services - Health | 33124     | Gender (On-demand TI)  | Female     |
+
+  #LL-324 Scenario 3: Updating the preference option on Campus level will not change the actual preference set on Contract
+ @LL-324 @UpdatePreferenceOnCampusDoesNotChangeOnContract
+ Scenario Outline: Updating the preference option on Campus level will not change the actual preference set on Contract
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for contract title "<contract title>"
+  And I click the contract link "<contract title>" from search results
+  And they click Add preference button in Contract Details
+  And they can select this option "<preference type option>" in Contract Details
+  And they select preference option "<preference>" in Contract Details
+  And they click save Contract Preference button in Contract Details
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And this preference "<preference>" is inherited by the Campus
+  And preference inherited from the Contract can be overridden "<override preference>" on the Campus level
+  And we see the reset option on the right corner and the text Customized appears
+  And I click account management link
+  And I search for contract title "<contract title>"
+  And I click the contract link "<contract title>" from search results
+  Then in contract page, the actual preference set "<preference>" still stays the same
+  And they remove added preference type option "<preference type option>" in Contract Details
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they remove added preference type option "<preference type option>" in Campus Details
+
+  Examples:
+   | username          | password  | contract title                                   | preference type option | campus id | preference | override preference |
+   | LLAdmin@looped.in | Octopus@6 | Department of Health and Human Services - Health | Gender (On-demand TI)  | 33124     | Female     | Preferred Female    |

--- a/test/pages/CampusDetails/CampusDetails.js
+++ b/test/pages/CampusDetails/CampusDetails.js
@@ -405,5 +405,17 @@ module.exports ={
 
     get campusGenderODTIDropdownOptionLocator() {
         return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//select[contains(@id,"GenderPreference")]/option[text()="<dynamicOption>"]';
-    }
+    },
+
+    get campusGenderODTIPreferenceAdded() {
+        return $('//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]');
+    },
+
+    get campusODTIPreferenceTypeResetIconLocator() {
+        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[@class="fa fa-fw fa-repeat"]';
+    },
+
+    get campusODTIPreferenceTypeCustomisedTextLocator() {
+        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[text()="CUSTOMISED"]';
+    },
 }

--- a/test/pages/CampusDetails/CampusDetails.js
+++ b/test/pages/CampusDetails/CampusDetails.js
@@ -411,11 +411,11 @@ module.exports ={
         return $('//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]');
     },
 
-    get campusODTIPreferenceTypeResetIconLocator() {
-        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[@class="fa fa-fw fa-repeat"]';
+    get campusODTIPreferenceTypeResetIcon() {
+        return $('//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[@class="fa fa-fw fa-repeat"]');
     },
 
-    get campusODTIPreferenceTypeCustomisedTextLocator() {
-        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[text()="CUSTOMISED"]';
+    get campusODTIPreferenceTypeCustomisedText() {
+        return $('//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//span[text()="CUSTOMISED"]');
     },
 }

--- a/test/pages/ContractManagement/ContractManagement.js
+++ b/test/pages/ContractManagement/ContractManagement.js
@@ -224,5 +224,9 @@ module.exports = {
 
     get contractGenderODTIPreferenceAdded() {
         return $('//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]');
-    }
+    },
+
+    get contractGenderODTIDropdownOptionLocator() {
+        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//select[contains(@id,"GenderPreference")]/option[text()="<dynamicOption>"]';
+    },
 }

--- a/test/pages/ContractManagement/ContractManagement.js
+++ b/test/pages/ContractManagement/ContractManagement.js
@@ -227,6 +227,6 @@ module.exports = {
     },
 
     get contractGenderODTIDropdownOptionLocator() {
-        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//select[contains(@id,"GenderPreference")]/option[text()="<dynamicOption>"]';
+        return '//span[text()="Gender (On-demand TI)"]/ancestor::div[@class="PreferenceInfoBlock Card"]//select[contains(@id,"Preference")]/option[text()="<dynamicOption>"]';
     },
 }

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -850,3 +850,23 @@ When(/^preference inherited from the Contract can be overridden "(.*)" on the Ca
     let optionSelectedStatus = action.isSelectedWait(campusGenderODTIDropdownOptionLocatorElement, 10000);
     chai.expect(optionSelectedStatus).to.be.true;
 })
+
+Then(/^the preference is added for the Campus$/, function () {
+    let genderODTIPreferenceAddedDisplayStatus = action.isVisibleWait(campusDetailsPage.campusGenderODTIPreferenceAdded, 10000);
+    chai.expect(genderODTIPreferenceAddedDisplayStatus).to.be.true;
+})
+
+When(/^this preference "(.*)" will have delete icon as this created by campus$/, function (optionLabel) {
+    let preferenceTypeRemoveIconElement = $(campusDetailsPage.campusPreferenceTypeRemoveIconLocator.replace("<dynamicOption>", optionLabel));
+    let preferenceTypeRemoveIconDisplayStatus = action.isVisibleWait(preferenceTypeRemoveIconElement,20000);
+    chai.expect(preferenceTypeRemoveIconDisplayStatus).to.be.true;
+})
+
+Then(/^we see the reset option on the right corner and the text Customized appears$/, function (optionLabel) {
+    let preferenceTypeResetIconElement = $(campusDetailsPage.campusODTIPreferenceTypeResetIconLocator);
+    let preferenceTypeResetIconDisplayStatus = action.isVisibleWait(preferenceTypeResetIconElement,20000);
+    chai.expect(preferenceTypeResetIconDisplayStatus).to.be.true;
+    let preferenceTypeCustomisedTextElement = $(campusDetailsPage.campusODTIPreferenceTypeCustomisedTextLocator);
+    let preferenceTypeCustomisedTextDisplayStatus = action.isVisibleWait(preferenceTypeCustomisedTextElement,20000);
+    chai.expect(preferenceTypeCustomisedTextDisplayStatus).to.be.true;
+})

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -862,11 +862,9 @@ When(/^this preference "(.*)" will have delete icon as this created by campus$/,
     chai.expect(preferenceTypeRemoveIconDisplayStatus).to.be.true;
 })
 
-Then(/^we see the reset option on the right corner and the text Customized appears$/, function (optionLabel) {
-    let preferenceTypeResetIconElement = $(campusDetailsPage.campusODTIPreferenceTypeResetIconLocator);
-    let preferenceTypeResetIconDisplayStatus = action.isVisibleWait(preferenceTypeResetIconElement,20000);
+Then(/^we see the reset option on the right corner and the text Customized appears$/, function () {
+    let preferenceTypeResetIconDisplayStatus = action.isVisibleWait(campusDetailsPage.campusODTIPreferenceTypeResetIcon,20000);
     chai.expect(preferenceTypeResetIconDisplayStatus).to.be.true;
-    let preferenceTypeCustomisedTextElement = $(campusDetailsPage.campusODTIPreferenceTypeCustomisedTextLocator);
-    let preferenceTypeCustomisedTextDisplayStatus = action.isVisibleWait(preferenceTypeCustomisedTextElement,20000);
+    let preferenceTypeCustomisedTextDisplayStatus = action.isVisibleWait(campusDetailsPage.campusODTIPreferenceTypeCustomisedText,20000);
     chai.expect(preferenceTypeCustomisedTextDisplayStatus).to.be.true;
 })

--- a/test/stepdefinition/AccountManagement/ContractSteps.js
+++ b/test/stepdefinition/AccountManagement/ContractSteps.js
@@ -398,3 +398,9 @@ When(/^related contract do not have Gender On-Demand TI preference added$/, func
     let genderODTIPreferenceAddedDisplayStatus = action.isVisibleWait(contractManagementPage.contractGenderODTIPreferenceAdded, 1000);
     chai.expect(genderODTIPreferenceAddedDisplayStatus).to.be.false;
 })
+
+Then(/^in contract page, the actual preference set "(.*)" still stays the same$/, function (option) {
+    let contractGenderODTIDropdownOptionLocatorElement = $(contractManagementPage.contractGenderODTIDropdownOptionLocator.replace("<dynamicOption>", option));
+    let optionSelectedStatus = action.isSelectedWait(contractGenderODTIDropdownOptionLocatorElement, 10000);
+    chai.expect(optionSelectedStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in Campus details and Contract Management pages.
- Added reusable step methods to verify the preference is added for the Campus, preference has delete icon when created by campus, reset option on the right corner and the text Customized appears and the to verify actual preference set still stays the same in contract page.
- Automated scenario 2 and scenario 3 from LL-324 ticket.