### PR TITLE
Automated scenario 5 from LL-334 ticket

### DIFF
--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -731,3 +731,53 @@ Feature: Campus Management features
   Examples:
    | username          | password  | campus id | contractor    | service     | from      | to      | level                 | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | eligible status   |
    | LLAdmin@looped.in | Octopus@6 | 33124     | Tigist KEBEDE | Interpreter | zz-Zenq2  | ENGLISH | Certified Interpreter | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Auto Notification |
+
+  #LL-334 Scenario 5: User edits the block and add the Date Finished to the past date at Campus / Contractor level
+ @LL-334 @ContractorExpireBlockOnCampus
+ Scenario Outline: User edits the block and add the Date Finished to the past date at Campus / Contractor level
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor>"
+  And Add Naati Accreditation "<service>","<from>","<to>","<level>" if not available
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And I click on Show Expired toggle in campus page
+  And the admin clicks on Remove on campus blocker
+  And they add a block on a contractor or interpreter "<contractor>"
+  And I click Interpreting header link
+  And I select "<dropdownfilter>" from the filter dropdown
+  And I click on new job request button
+  And I enter campus pin "<campus pin>"
+  And click on Job Type option "<request job type>" in Job Requester Details
+  And I select "<Requester Name>" from the requester name dropdown
+  And I click next button
+  And I select language "<language>"
+  And I select assignment type "<assignment type>"
+  And I enter schedule "<date>" and "<time>"
+  And I enter "<email>" email address
+  And I click save and proceed to summary button
+  And I handle duplicate job warning window
+  And I click submit button
+  And the job created success message should appear
+  And I search for created job request
+  And I verify the job is listed in search results
+  And I click on first job id from interpreting job list
+  And I switch to the job allocation window
+  And the contractor or interpreter "<contractor>" is unable to view or accept any job for that campus or Organisation
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And user makes the block "<active block name>" as expired by adding past date to Date Finished field on Campus page or the Contractor page
+  And I click Interpreting header link
+  And I select "<dropdownfilter>" from the filter dropdown
+  And I search for created job request
+  And I verify the job is listed in search results
+  And I click on first job id from interpreting job list
+  And I switch to the job allocation window
+  And the contractor above "<contractor>" status will be "<eligible status>" for the Job
+  Then on refreshing the Job page, the contractor "<contractor>" will be eligible for the job
+
+  Examples:
+   | username          | password  | campus id | contractor    | service     | from      | to      | level                 | request job type     | dropdownfilter | campus pin | Requester Name      | language   | assignment type   | date         | time  | email        | eligible status   | active block name                 |
+   | LLAdmin@looped.in | Octopus@6 | 33124     | Tigist KEBEDE | Interpreter | zz-Zenq2  | ENGLISH | Certified Interpreter | Pre-Booked Telephone |  Management    |  33124     |  Automation Tester  |  zz-Zenq2  |   Halfday         | short notice | 09:30 | hh@bb.com.au | Auto Notification | BOLTON CLARKE - DH RDNS - DH RDNS |

--- a/test/features/ODTI/ODTIInterpretersCSO.feature
+++ b/test/features/ODTI/ODTIInterpretersCSO.feature
@@ -179,6 +179,7 @@ Feature: ODTI Interpreters CSO features
     And they are navigated to the ODTI page
     And they will see the ODTI Interpreters page by default
     And the table will appear
+    And user cancels the already existing ongoing jobs for the language "<language>" and interpreter "<contractor>" on behalf of "<Requester Name>"
     And the user will be able to search for a language "<language>"
     And the user will be able to select status for the selected language using options "<logon status option>"
     Then the table will show the current ongoing job for the interpreter "<contractor>"
@@ -246,6 +247,7 @@ Feature: ODTI Interpreters CSO features
     And they are navigated to the ODTI page
     And they will see the ODTI Interpreters page by default
     And the table will appear
+    And user cancels the already existing ongoing jobs for the language "<language>" and interpreter "<contractor>" on behalf of "<Requester Name>"
     And the user will be able to search for a language "<language>"
     And the user will be able to select status for the selected language using options "<logon status option>"
     Then the table will also show the next pre-booked job for the interpreter "<contractor>"
@@ -374,6 +376,7 @@ Feature: ODTI Interpreters CSO features
     And they are navigated to the ODTI page
     And they will see the ODTI Interpreters page by default
     And the table will appear
+    And user cancels the already existing ongoing jobs for the language "<language>" and interpreter "<contractor>" on behalf of "<Requester Name>"
     And the user will be able to search for a language "<language>"
     And the user will be able to select status for the selected language using options "<logon status option>"
     And they click on the hyperlinked Job ID "<contractor>"

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -908,3 +908,19 @@ When(/^the user is on the Organisation page$/, function () {
     action.isVisibleWait(campusDetailsPage.campusOrganizationLink,10000);
     action.clickElement(campusDetailsPage.campusOrganizationLink);
 })
+
+When(/^user makes the block "(.*)" as expired by adding past date to Date Finished field on Campus page or the Contractor page$/, function (blockName) {
+    let activeBlockerLinkElement = $(campusDetailsPage.activeBlockerLinkLocator.replace("<dynamic>", blockName));
+    action.isVisibleWait(activeBlockerLinkElement, 10000);
+    action.clickElement(activeBlockerLinkElement);
+    action.enterValue(campusDetailsPage.endDateContractor, "17-04-2023");
+    action.pressKeys("Tab");
+    action.isVisibleWait(campusDetailsPage.saveButtonOnBlockingPopup, 10000);
+    action.clickElement(campusDetailsPage.saveButtonOnBlockingPopup);
+    action.isNotVisibleWait(campusDetailsPage.saveButtonOnBlockingPopup, 10000);
+})
+
+When(/^I click on Show Expired toggle in campus page$/, function () {
+    action.isVisibleWait(campusDetailsPage.showExpiredBlocksToggleCheck, 10000);
+    action.clickElement(campusDetailsPage.showExpiredBlocksToggleCheck);
+})

--- a/test/stepdefinition/ODTI/ODTIInterpretersSteps.js
+++ b/test/stepdefinition/ODTI/ODTIInterpretersSteps.js
@@ -40,7 +40,8 @@ Then(/^the label will be: Language$/, function () {
 })
 
 Then(/^the user will be able to search for a language "(.*)"$/, function (language) {
-    if (action.isVisibleWait(ODTIInterpretersPage.languageDropdownSearchBox, 10000) === false) {
+    browser.refresh();
+    if (action.isVisibleWait(ODTIInterpretersPage.languageDropdownSearchBox, 5000) === false) {
         action.clickElement(ODTIInterpretersPage.ODTILanguageSwitchDropdown);
     }
     action.enterValueAndPressReturn(ODTIInterpretersPage.languageDropdownSearchBox, language);
@@ -289,4 +290,42 @@ Then(/^they can swap to the ODTI Jobs page$/, function () {
     let ODTIJobsPageOption = $(ODTIInterpretersPage.ODTIJobsSwitchDropdownOptionLocator.replace("<dynamic>", "ODTI Jobs"));
     let ODTIJobsPageSelectedStatus = action.isSelectedWait(ODTIJobsPageOption, 10000);
     chai.expect(ODTIJobsPageSelectedStatus).to.be.true;
+})
+
+When(/^user cancels the already existing ongoing jobs for the language "(.*)" and interpreter "(.*)" on behalf of "(.*)"$/, function (language, interpreter, requesterName) {
+    let ODTIJobsPageWindowHandle = action.getWindowHandle();
+    if (action.isVisibleWait(ODTIInterpretersPage.languageDropdownSearchBox, 5000) === false) {
+        action.clickElement(ODTIInterpretersPage.ODTILanguageSwitchDropdown);
+    }
+    action.enterValueAndPressReturn(ODTIInterpretersPage.languageDropdownSearchBox, language);
+    browser.pause(5000);
+    let jobIDLinkElement = $(ODTIInterpretersPage.interpreterResultsLinkTextLinkLocator.replace("<dynamicRowLinkText>", interpreter).replace("<dynamicColumnNumber>", "10"));
+    let counter = 0;
+    while (GlobalData.CURRENT_JOB_ID.toString() !== action.getElementText(jobIDLinkElement) && action.isVisibleWait(jobIDLinkElement, 10000) === true && counter <= 6) {
+        console.log("Cancelling the already existing ongoing jobs for the language and interpreter")
+        action.clickElement(jobIDLinkElement);
+        action.navigateToLatestWindow();
+        action.isVisibleWait(ODTIInterpretersPage.jobIDTextInODTIJobAllocationPage, 10000);
+        action.isVisibleWait(jobRequestPage.jobStatusLink, 10000);
+        action.clickElement(jobRequestPage.jobStatusLink);
+        action.isVisibleWait(jobRequestPage.jobStatusDropdown, 10000);
+        action.selectTextFromDropdown(jobRequestPage.jobStatusDropdown, "Cancel");
+        action.isVisibleWait(jobRequestPage.jobCancelConfirmationPopupText, 10000);
+        action.isVisibleWait(jobRequestPage.cancelConfirmationYesButton, 10000);
+        action.clickElement(jobRequestPage.cancelConfirmationYesButton);
+        action.isVisibleWait(jobRequestPage.cancelReasonDropdown, 10000);
+        action.selectTextFromDropdown(jobRequestPage.cancelReasonDropdown, "Job request error (Date,Time, Duration, etc..)");
+        action.isVisibleWait(jobRequestPage.cancelOnBehalfDropdown, 10000);
+        action.selectTextFromDropdown(jobRequestPage.cancelOnBehalfDropdown, requesterName);
+        action.isVisibleWait(jobRequestPage.submitButtonConfirmationPopup, 10000);
+        action.clickElement(jobRequestPage.submitButtonConfirmationPopup);
+        action.isVisibleWait(jobRequestPage.searchByJobIdTextBox, 10000);
+        action.navigateToWindowHandle(ODTIJobsPageWindowHandle);
+        browser.refresh();
+        if (action.isVisibleWait(ODTIInterpretersPage.languageDropdownSearchBox, 5000) === false) {
+            action.clickElement(ODTIInterpretersPage.ODTILanguageSwitchDropdown);
+        }
+        action.isVisibleWait(ODTIInterpretersPage.languageDropdownSearchBox, 5000);
+        action.enterValueAndPressReturn(ODTIInterpretersPage.languageDropdownSearchBox, language);
+    }
 })

--- a/test/utils/datetime.js
+++ b/test/utils/datetime.js
@@ -248,7 +248,7 @@ module.exports={
         //Changing time (from AEDT) to AEST format
         temp_date.setHours(temp_date.getHours() - 1);
         temp_date.setMinutes(temp_date.getMinutes() + 10);
-        temp_time = temp_date.getHours() + ":" + `${temp_date.getMinutes()}`.padStart(2, "0");
+        temp_time = `${temp_date.getHours()}`.padStart(2, "0") + ":" + `${temp_date.getMinutes()}`.padStart(2, "0");
         return temp_time;
     },
 


### PR DESCRIPTION
- Updated scenarios 6c, 6d and 8 from LL-447 to fix dependency issues and updated method to get fifteen minutes confirmation time.
- Added reusable step methods to cancel the already existing ongoing jobs for the language and interpreter, to make a block expire by adding past date to Date Finished field and to click on Show Expired toggle in campus page.
- Automated scenario 5 from LL-334 ticket.