### PR TITLE
Automated scenario 1a from LL-489 ticket

### DIFF
--- a/test/data/GlobalData.js
+++ b/test/data/GlobalData.js
@@ -34,4 +34,5 @@ module.exports={
     ACTUAL_ACCOUNT_CREATION_DATE:"",
     ODTI_JOB_CONTRACT_ID:"",
     ODTI_JOBS_PAGE_WINDOW_HANDLE:"",
+    ODTI_DID_URL:"",
 }

--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -1,0 +1,20 @@
+@ODTIJobsCBO
+Feature: ODTI_UI Campus Configuration features
+
+  Background: Load the ODTI DID Configurations page
+    Given the looped in login page is opened
+
+ #LL-489: Scenario 1a - Campus ODTI Configuration (New)
+  @LL-489 @CampusODTIConfigurationNew
+  Scenario Outline: Campus ODTI Configuration (New)
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And the Admin is on the Campus Configuration screen
+    And the new Campus Configuration Page is displayed
+    And the Service Type is displayed with General TI type by default and not changeable
+    And the Campus PIN input and configuration section are displayed
+
+    Examples:
+      | username          | password  |
+      | LLAdmin@looped.in | Octopus@6 |

--- a/test/pages/ODTI_UI/DIDConfigurations.js
+++ b/test/pages/ODTI_UI/DIDConfigurations.js
@@ -1,0 +1,11 @@
+
+module.exports = {
+
+    get campusConfigurationTab() {
+        return $('//div[@role="tab" and text()="Campus Configuration"]');
+    },
+
+    get newConfigurationButtonUnderCampusConfiguration() {
+        return $('//input[@value="New Configuration" and contains(@onclick,"Campus")]');
+    }
+}

--- a/test/pages/ODTI_UI/NewCampusConfiguration.js
+++ b/test/pages/ODTI_UI/NewCampusConfiguration.js
@@ -1,0 +1,16 @@
+
+module.exports = {
+
+    get TIServiceTypeDropdownDisabled() {
+        return $('//select[contains(@id,"TIServiceType") and @disabled]');
+    },
+
+    get campusPinInputTextBox() {
+        return $('//input[contains(@id,"DIDConfiguration_CampusBillToId")]');
+    },
+
+    get configurationSection() {
+        return $('//div[text()="Configuration"]/parent::div[contains(@class,"card-sectioned-top")]');
+    }
+
+}

--- a/test/stepdefinition/Login/LoginSteps.js
+++ b/test/stepdefinition/Login/LoginSteps.js
@@ -67,3 +67,7 @@ Then(/^they will be able to login$/, function () {
     let loginButtonDisplayStatus = action.isVisibleWait(Login.loginButton, 1000);
     chai.expect(loginButtonDisplayStatus).to.be.false;
 })
+
+Given(/^the ODTI DID Configurations page is opened$/, function () {
+    browser.url(GlobalData.ODTI_DID_URL);
+})

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -1,0 +1,10 @@
+When(/^the Admin clicks on Campus Configuration tab$/, function () {
+    action.isVisibleWait(DIDConfigurationsPage.campusConfigurationTab, 10000);
+    action.clickElement(DIDConfigurationsPage.campusConfigurationTab);
+})
+
+When(/^the Admin is on the Campus Configuration screen$/, function () {
+    action.isVisibleWait(DIDConfigurationsPage.newConfigurationButtonUnderCampusConfiguration, 10000);
+    action.clickElement(DIDConfigurationsPage.newConfigurationButtonUnderCampusConfiguration);
+})
+

--- a/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
@@ -1,0 +1,16 @@
+When(/^the new Campus Configuration Page is displayed$/, function () {
+    let pageTitleActual = action.getPageTitle();
+    chai.expect(pageTitleActual).to.equal("New Campus Configuration");
+})
+
+Then(/^the Service Type is displayed with General TI type by default and not changeable$/, function () {
+    let TIServiceTypeDropdownDisabledDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.TIServiceTypeDropdownDisabled, 10000);
+    chai.expect(TIServiceTypeDropdownDisabledDisplayStatus).to.be.true;
+})
+
+Then(/^the Campus PIN input and configuration section are displayed$/, function () {
+    let campusPinInputDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.campusPinInputTextBox, 10000);
+    chai.expect(campusPinInputDisplayStatus).to.be.true;
+    let configurationSectionDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.configurationSection, 10000);
+    chai.expect(configurationSectionDisplayStatus).to.be.true;
+})

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -30,6 +30,8 @@ var adminPage = require('./test/pages/Home/AdminPage.js')
 var ODTIJobsPage = require('./test/pages/ODTI/ODTIJobsPage.js')
 var ODTIInterpretersPage = require('./test/pages/ODTI/ODTIInterpretersPage.js')
 var organisationPage = require('./test/pages/AccountManagement/OrganisationDetails.js')
+var DIDConfigurationsPage = require('./test/pages/ODTI_UI/DIDConfigurations.js')
+var newCampusConfigurationPage = require('./test/pages/ODTI_UI/NewCampusConfiguration.js')
 
 var chai= require('chai')
 var action=require('./test/utils/actions')
@@ -343,6 +345,8 @@ exports.config = {
         global.ODTIJobsPage = ODTIJobsPage
         global.ODTIInterpretersPage = ODTIInterpretersPage
         global.organisationPage = organisationPage
+        global.DIDConfigurationsPage = DIDConfigurationsPage
+        global.newCampusConfigurationPage = newCampusConfigurationPage
         //global.translationsPage=translationsPage
         //global.xtmPage = xtmPage
         

--- a/wdio.uat.conf.js
+++ b/wdio.uat.conf.js
@@ -3,6 +3,7 @@ const baseConfig = require('./wdio.conf').config;
 const GlobalData=require('./test/data/GlobalData')
 GlobalData.BASE_URL="https://li-uat.languageloop.com.au/LoopedIn_th/Login.aspx"
 GlobalData.DEV_URL="https://li-uat.languageloop.com.au/DeveloperScreen/Home.aspx"
+GlobalData.ODTI_DID_URL="https://li-uat.languageloop.com.au/OnDemandTI_UI/"
 
 
 const uatconfig = Object.assign(baseConfig, {


### PR DESCRIPTION
- Added global URL variable for ODTI DID page in uat configuration file.
- Added new locators in DID Configurations and New Campus Configurations pages.
- Added reusable step methods to open DID Configurations page, click on new configuration button, to verify new Campus Configuration Page, the Service Type with General TI type by default and the Campus PIN input and configuration sections are displayed.
- Automated scenario 1a from LL-489 ticket.