### PR TITLE
Automated scenario 1c from LL-489 ticket

### DIFF
--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -33,3 +33,19 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | campus                  |
       | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |
+
+    #LL-489: Scenario 1c - Campus ODTI Configuration (Duplicate)
+  @LL-489 @CampusODTIConfigurationDuplicate
+  Scenario Outline: Campus ODTI Configuration (Duplicate)
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And the Admin is on the Duplicate Campus Configuration screen of Campus "<campus>"
+    And the new Campus Configuration Page is displayed
+    Then the Campus PIN input and Service Type Dropdown are displayed upon clicking duplicate
+    And the saved configuration is displayed upon clicking duplicate
+    And the Campus PIN is blank upon clicking duplicate
+
+    Examples:
+      | username          | password  | campus                  |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |

--- a/test/pages/ODTI_UI/DIDConfigurations.js
+++ b/test/pages/ODTI_UI/DIDConfigurations.js
@@ -15,5 +15,13 @@ module.exports = {
 
     get editCampusConfigurationLinksLocator() {
         return '//a[text()="<dynamicCampusPin>"]/parent::td/following-sibling::td/a[text()="Edit"]';
+    },
+
+    get duplicateCampusConfigurationLinkLocator() {
+        return '(//a[text()="<dynamicCampusPin>"]/parent::td/following-sibling::td/a[text()="Duplicate"])[<dynamicIndex>]';
+    },
+
+    get duplicateCampusConfigurationLinksLocator() {
+        return '//a[text()="<dynamicCampusPin>"]/parent::td/following-sibling::td/a[text()="Duplicate"]';
     }
 }

--- a/test/pages/ODTI_UI/NewCampusConfiguration.js
+++ b/test/pages/ODTI_UI/NewCampusConfiguration.js
@@ -11,6 +11,10 @@ module.exports = {
 
     get configurationSection() {
         return $('//div[text()="Configuration"]/parent::div[contains(@class,"card-sectioned-top")]');
+    },
+
+    get savedConfiguration() {
+        return $('//div[contains(@id,"DIDConfigurationForm")]');
     }
 
 }

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -332,7 +332,7 @@ When(/^I click no change required button$/,function()
 
 Then(/^the job created success message should appear$/, function(){
   console.time('t2')
-  action.isVisibleWait(jobRequestPage.successMessageText,30000);
+  action.isVisibleWait(jobRequestPage.successMessageText,90000);
   jobRequestPage.successMessageText.waitForExist({timeout:12000})
   chai.expect(action.elementExists(jobRequestPage.successMessage)).to.be.true
   browser.waitUntil(

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -20,3 +20,15 @@ When(/^the Admin is on the Edit Campus Configuration screen of Campus "(.*)"$/, 
     }
 })
 
+When(/^the Admin is on the Duplicate Campus Configuration screen of Campus "(.*)"$/, function (campusPin) {
+    let editCampusConfigurationLinksCount = $$(DIDConfigurationsPage.duplicateCampusConfigurationLinksLocator.replace("<dynamicCampusPin>", campusPin)).length;
+    for (let index = 1; index <= editCampusConfigurationLinksCount; index++) {
+        let editCampusConfigurationLink = $(DIDConfigurationsPage.duplicateCampusConfigurationLinkLocator.replace("<dynamicCampusPin>", campusPin).replace("<dynamicIndex>", index.toString()));
+        let editLinkVisible = action.isVisibleWait(editCampusConfigurationLink, 1000);
+        if (editLinkVisible) {
+            action.clickElement(editCampusConfigurationLink);
+            break;
+        }
+    }
+})
+

--- a/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
@@ -14,3 +14,20 @@ Then(/^the Campus PIN input and configuration section are displayed$/, function 
     let configurationSectionDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.configurationSection, 10000);
     chai.expect(configurationSectionDisplayStatus).to.be.true;
 })
+
+Then(/^the saved configuration is displayed upon clicking duplicate$/, function () {
+    let savedConfigurationDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.savedConfiguration, 10000);
+    chai.expect(savedConfigurationDisplayStatus).to.be.true;
+})
+
+Then(/^the Campus PIN input and Service Type Dropdown are displayed upon clicking duplicate$/, function () {
+    let campusPinInputDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.campusPinInputTextBox, 10000);
+    chai.expect(campusPinInputDisplayStatus).to.be.true;
+    let TIServiceTypeDropdownDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.TIServiceTypeDropdownDisabled, 10000);
+    chai.expect(TIServiceTypeDropdownDisplayStatus).to.be.true;
+})
+
+Then(/^the Campus PIN is blank upon clicking duplicate$/, function () {
+    let campusPinInputElementHTML = action.getElementHTML(newCampusConfigurationPage.campusPinInputTextBox);
+    chai.expect(campusPinInputElementHTML).to.not.includes("value");
+})


### PR DESCRIPTION
- Increased wait in Job creation success message verification step.
- Added new locators in DID Configurations and New Campus Configurations pages.
- Added reusable step methods to verify the Admin is on the Duplicate Campus Configuration screen of Campus, the saved configuration, Campus PIN input and Service Type Dropdown are displayed upon clicking duplicate and Campus PIN is blank upon clicking duplicate.
- Automated scenario 1c and started automating scenario 2 from LL-489 ticket - In progress.