### PR TITLE
Automated scenario 2 from LL-489 ticket

### DIFF
--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -49,3 +49,18 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | campus                  |
       | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |
+
+    #LL-489: Scenario 2 - Entering a Campus PIN
+  @LL-489 @EnteringCampusPIN
+  Scenario Outline: Entering a Campus PIN
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And the Admin is on the Campus Configuration screen
+    And has typed in a Campus PIN "<campus pin>"
+    Then the PIN is searched
+    And the Campus name "<campus name>" is displayed below the input box
+
+    Examples:
+      | username          | password  | campus pin | campus name     |
+      | LLAdmin@looped.in | Octopus@6 | 29449      | Contoso Pty LTD |

--- a/test/pages/ODTI_UI/NewCampusConfiguration.js
+++ b/test/pages/ODTI_UI/NewCampusConfiguration.js
@@ -15,6 +15,10 @@ module.exports = {
 
     get savedConfiguration() {
         return $('//div[contains(@id,"DIDConfigurationForm")]');
+    },
+
+    get campusNameBelowInputTextBox() {
+        return $('//span[contains(@id,"IsWithCampus")]/a');
     }
 
 }

--- a/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
@@ -31,3 +31,18 @@ Then(/^the Campus PIN is blank upon clicking duplicate$/, function () {
     let campusPinInputElementHTML = action.getElementHTML(newCampusConfigurationPage.campusPinInputTextBox);
     chai.expect(campusPinInputElementHTML).to.not.includes("value");
 })
+
+When(/^has typed in a Campus PIN "(.*)"$/, function (campusPin) {
+    action.isVisibleWait(newCampusConfigurationPage.campusPinInputTextBox, 10000);
+    action.enterValue(newCampusConfigurationPage.campusPinInputTextBox,campusPin);
+})
+
+Then(/^the PIN is searched$/, function () {
+    let searchedCampusResultDisplayStatus = action.isVisibleWait(newCampusConfigurationPage.campusNameBelowInputTextBox, 10000);
+    chai.expect(searchedCampusResultDisplayStatus).to.be.true;
+})
+
+Then(/^the Campus name "(.*)" is displayed below the input box$/, function (campusName) {
+    let campusNameTextBelowInputBox = action.getElementText(newCampusConfigurationPage.campusNameBelowInputTextBox);
+    chai.expect(campusNameTextBelowInputBox).to.equal(campusName);
+})


### PR DESCRIPTION
- Added new locators in New Campus Configurations page.
- Added reusable step methods to enter a Campus PIN in new Campus Configuration Page, verify the pin is searched and the Campus name is displayed below the input box.
- Automated scenario 2 and started automating scenario 5 from LL-489 ticket.