### PR TITLE
Automated scenario 5 from LL-489 ticket

### DIFF
--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -64,3 +64,21 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | campus pin | campus name     |
       | LLAdmin@looped.in | Octopus@6 | 29449      | Contoso Pty LTD |
+
+    #LL-489: Scenario 5 - Cancel
+  @LL-489 @CampusODTIConfigurationCancel
+  Scenario Outline: Campus ODTI Configuration Cancel
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And the Admin is on the Campus Configuration screen
+    And has typed in a Campus PIN "<campus pin>"
+    And the PIN is searched
+    And the user has filled in all the required data configuration toggles "<configuration toggles>"
+    And the user has clicked the CANCEL button
+    Then the data entered is not saved
+    And the admin is navigated back to the configuration list screen
+
+    Examples:
+      | username          | password  | configuration toggles                                                                                      | campus pin |
+      | LLAdmin@looped.in | Octopus@6 | Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number | 33124      |

--- a/test/pages/ODTI_UI/NewCampusConfiguration.js
+++ b/test/pages/ODTI_UI/NewCampusConfiguration.js
@@ -19,6 +19,14 @@ module.exports = {
 
     get campusNameBelowInputTextBox() {
         return $('//span[contains(@id,"IsWithCampus")]/a');
+    },
+
+    get configurationToggleCheckboxLocator() {
+        return '//label[text()="<dynamic>"]/parent::div//input';
+    },
+
+    get cancelButton(){
+        return $('//input[@value="Cancel"]')
     }
 
 }

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -32,3 +32,7 @@ When(/^the Admin is on the Duplicate Campus Configuration screen of Campus "(.*)
     }
 })
 
+Then(/^the admin is navigated back to the configuration list screen$/, function () {
+    let pageTitleActual = action.getPageTitle();
+    chai.expect(pageTitleActual).to.includes("DID Configurations");
+})

--- a/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewCampusConfigurationSteps.js
@@ -46,3 +46,22 @@ Then(/^the Campus name "(.*)" is displayed below the input box$/, function (camp
     let campusNameTextBelowInputBox = action.getElementText(newCampusConfigurationPage.campusNameBelowInputTextBox);
     chai.expect(campusNameTextBelowInputBox).to.equal(campusName);
 })
+
+When(/^the user has filled in all the required data configuration toggles "(.*)"$/, function (configurationToggles) {
+    let configurationTogglesList = configurationToggles.split(",")
+    for (let index=0; index<configurationTogglesList.length; index++){
+        let configurationToggleElement = $(newCampusConfigurationPage.configurationToggleCheckboxLocator.replace("<dynamic>",configurationTogglesList[index]));
+        action.isExistingWait(configurationToggleElement,10000);
+        action.clickWithOutWait(configurationToggleElement);
+    }
+})
+
+When(/^the user has clicked the CANCEL button$/, function () {
+    action.isVisibleWait(newCampusConfigurationPage.cancelButton,10000);
+    action.clickElement(newCampusConfigurationPage.cancelButton);
+})
+
+Then(/^the data entered is not saved$/, function () {
+    let pageTitleActual = action.getPageTitle();
+    chai.expect(pageTitleActual).to.not.includes("New Campus Configuration");
+})


### PR DESCRIPTION
- Added new locators in New Campus Configurations page.
- Added reusable step methods to navigate back to the configuration list screen, fill in all the required data, click the CANCEL button and verify the data entered is not saved.
- Automated scenario 5 from LL-489 ticket.