### PR TITLE
Automated scenario 2a and 2b from LL-514 ticket

### DIFF
--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -910,3 +910,36 @@ Feature: Campus Management features
   Examples:
    | username          | password  | contract title                                   | customised field name | max length | audio label      | campus id |
    | LLAdmin@looped.in | Octopus@6 | Department of Health and Human Services - Health | AutomationField       | 50         | automation label | 33124     |
+
+  #LL-514 Scenario 2a: Admin views customised ODTI field
+ @LL-514 @ViewsCustomizedODTIFields
+ Scenario Outline: Admin views customised ODTI field
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click add Customised Field
+  And the Manage Customised Field modal is displayed
+  Then they will see the ‘Audible in ODTI’ checkbox
+  And the letters ‘ODTI’ will be a hyperlink
+
+  Examples:
+   | username          | password  | campus id |
+   | LLAdmin@looped.in | Octopus@6 | 33124     |
+
+  #LL-514 Scenario 2b: Admin views customised ODTI field tooltip
+ @LL-514 @ViewsCustomizedODTIFieldTooltip
+ Scenario Outline: Admin views customised ODTI field tooltip
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click add Customised Field
+  And the Manage Customised Field modal is displayed
+  And they will see the ‘Audible in ODTI’ checkbox
+  And they hover over the text ‘ODTI’
+  Then a tooltip will display with the following text: On Demand Telephone Interpreting
+
+  Examples:
+   | username          | password  | campus id |
+   | LLAdmin@looped.in | Octopus@6 | 33124     |

--- a/test/pages/CampusDetails/CampusDetails.js
+++ b/test/pages/CampusDetails/CampusDetails.js
@@ -478,4 +478,24 @@ module.exports ={
     get overrideCampusDataButtonOnManageCustomisedField() {
         return $('//input[@value="Override Contract Data"]')
     },
+
+    get addCustomizedFieldLink() {
+        return $('//a[contains(text(),"Add customized field")]');
+    },
+
+    get manageCustomizedFieldModal() {
+        return $('//span[text()="Manage Customized Field"]/parent::div//parent::div[contains(@id,"DialogContainer")]');
+    },
+
+    get audibleInODTICheckboxOnManageCustomizedFiled() {
+        return $('//div[contains(text(),"Audible in")]/preceding-sibling::input');
+    },
+
+    get audibleInODTICheckboxODTIHyperlink() {
+        return $('//div[contains(text(),"Audible in")]/span[text()="ODTI"]');
+    },
+
+    get onDemandTelephoneInterpretingTextOnTooltip() {
+        return $('//span[text()="On Demand Telephone Interpreting"]');
+    }
 }

--- a/test/pages/CampusDetails/CampusDetails.js
+++ b/test/pages/CampusDetails/CampusDetails.js
@@ -487,7 +487,7 @@ module.exports ={
         return $('//span[text()="Manage Customized Field"]/parent::div//parent::div[contains(@id,"DialogContainer")]');
     },
 
-    get audibleInODTICheckboxOnManageCustomizedFiled() {
+    get audibleInODTICheckboxOnManageCustomizedField() {
         return $('//div[contains(text(),"Audible in")]/preceding-sibling::input');
     },
 

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -950,7 +950,7 @@ When(/^the Manage Customised Field modal is displayed$/, function () {
 })
 
 Then(/^they will see the ‘Audible in ODTI’ checkbox$/, function () {
-    let audibleInODTICheckboxDisplayStatus = action.isVisibleWait(campusDetailsPage.audibleInODTICheckboxOnManageCustomizedFiled, 10000);
+    let audibleInODTICheckboxDisplayStatus = action.isVisibleWait(campusDetailsPage.audibleInODTICheckboxOnManageCustomizedField, 10000);
     chai.expect(audibleInODTICheckboxDisplayStatus).to.be.true;
 })
 

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -938,3 +938,40 @@ Then(/^the Customised field can be overridden on the Campus page$/, function () 
     chai.expect(overrideCampusDataButtonOnManageCustomisedFieldDisplayStatus).to.be.true;
     action.clickElement(campusDetailsPage.overrideCampusDataButtonOnManageCustomisedField);
 })
+
+When(/^they click add Customised Field$/, function () {
+    action.isVisibleWait(campusDetailsPage.addCustomizedFieldLink, 10000);
+    action.clickElement(campusDetailsPage.addCustomizedFieldLink);
+})
+
+When(/^the Manage Customised Field modal is displayed$/, function () {
+    let manageCustomizedFieldModalDisplayStatus = action.isVisibleWait(campusDetailsPage.manageCustomizedFieldModal, 10000);
+    chai.expect(manageCustomizedFieldModalDisplayStatus).to.be.true;
+})
+
+Then(/^they will see the ‘Audible in ODTI’ checkbox$/, function () {
+    let audibleInODTICheckboxDisplayStatus = action.isVisibleWait(campusDetailsPage.audibleInODTICheckboxOnManageCustomizedFiled, 10000);
+    chai.expect(audibleInODTICheckboxDisplayStatus).to.be.true;
+})
+
+When(/^the letters ‘ODTI’ will be a hyperlink$/, function () {
+    let audibleInODTICheckboxODTIHyperlinkClass = action.getElementAttribute(campusDetailsPage.audibleInODTICheckboxODTIHyperlink, "class");
+    chai.expect(audibleInODTICheckboxODTIHyperlinkClass).to.includes("Link")
+})
+
+When(/^they hover over the text ‘ODTI’$/, function () {
+    action.isVisibleWait(campusDetailsPage.audibleInODTICheckboxODTIHyperlink, 10000);
+    browser.execute((el) => {
+        const hoverEvent = new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window
+        });
+        el.dispatchEvent(hoverEvent);
+    }, campusDetailsPage.audibleInODTICheckboxODTIHyperlink);
+})
+
+Then(/^a tooltip will display with the following text: On Demand Telephone Interpreting$/, function () {
+    let onDemandTelephoneInterpretingTextOnTooltipExistStatus = action.isExistingWait(campusDetailsPage.onDemandTelephoneInterpretingTextOnTooltip, 3000);
+    chai.expect(onDemandTelephoneInterpretingTextOnTooltipExistStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in Campus Details page.
- Added reusable step methods to click add Customized Field in campus, to verify Manage Customized  Field modal and ‘Audible in ODTI’ checkbox is displayed, to check letters ‘ODTI’ are hyperlink, to hover over the text ‘ODTI’ and verify a tooltip is displayed with the text On Demand Telephone Interpreting.
- Automated scenario 2a and 2b from LL-514 ticket.