### PR TITLE
Automated scenarios 3 and 4 from LL-514 ticket

### DIFF
--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -943,3 +943,39 @@ Feature: Campus Management features
   Examples:
    | username          | password  | campus id |
    | LLAdmin@looped.in | Octopus@6 | 33124     |
+
+  #LL-514 Scenario 3: Admin selects ‘Audible in ODTI’
+ @LL-514 @AdminSelectsAudibleInODTI
+ Scenario Outline: Admin selects ‘Audible in ODTI’
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click add Customised Field
+  And they select ‘Audible in ODTI’ checkbox
+  And the Max Length and Audio-label fields will display
+  And the Max Length and Audio-label fields will be mandatory
+
+  Examples:
+   | username          | password  | campus id |
+   | LLAdmin@looped.in | Octopus@6 | 33124     |
+
+  #LL-514 Scenario 4: Admin fills out ODTI fields
+ @LL-514 @AdminFillsODTIFields
+ Scenario Outline: Admin fills out ODTI fields
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click add Customised Field
+  And they select ‘Audible in ODTI’ checkbox
+  And the Max Length and Audio-label fields will display
+  And the Admin enters Customised ODTI Field data "<customised field name>","<max length>","<audio label>" in campus
+  And the Admin clicks the ‘Add’ button On Manage Customized Field
+  Then the customised field will be created
+  And there is a checkbox checked for the above custom field under the column Audible in ODTI
+  And the Customised ODTI Field is deleted in Campus
+
+  Examples:
+   | username          | password  | campus id | customised field name | max length | audio label      |
+   | LLAdmin@looped.in | Octopus@6 | 33124     | AutomationField       | 50         | automation label |

--- a/test/pages/CampusDetails/CampusDetails.js
+++ b/test/pages/CampusDetails/CampusDetails.js
@@ -497,5 +497,41 @@ module.exports ={
 
     get onDemandTelephoneInterpretingTextOnTooltip() {
         return $('//span[text()="On Demand Telephone Interpreting"]');
-    }
+    },
+
+    get maxLengthTextBoxOnManageCustomizedField() {
+        return $('//input[contains(@id,"CustomizedFields_ODTIInputMaxlength")]');
+    },
+
+    get audioLabelTextBoxOnManageCustomizedField() {
+        return $('//input[contains(@id,"CustomizedFields_ODTIAudioName")]');
+    },
+
+    get maxLengthFieldLabelOnManageCustomizedField() {
+        return $('//label[contains(@for,"CustomizedFields_ODTIInputMaxlength")]');
+    },
+
+    get audioLabelFieldLabelOnManageCustomizedField() {
+        return $('//label[contains(@for,"CustomizedFields_ODTIAudioName")]');
+    },
+
+    get fieldNameTextBoxOnManageCustomizedField() {
+        return $('//label[text()="Field Name"]/following-sibling::input');
+    },
+
+    get freeTextRadioButtonOnManageCustomizedField() {
+        return $('//div[text()="Free text"]/parent::div/parent::div//input[@type="radio"]');
+    },
+
+    get addButtonOnManageCustomizedField() {
+        return $('//input[@value="Add" and (not(contains(@id,"AddModal2")))]');
+    },
+
+    get customisedFieldsOverrideAudibleInODTICheckboxLocator() {
+        return '//a[text()="<dynamic>"]/parent::div/parent::div/parent::td/following-sibling::td[5]//input[@type="checkbox"]';
+    },
+
+    get customisedFieldDeleteIconDynamicLocator() {
+        return '//a[text()="<dynamic>"]/parent::div/parent::div/parent::td/following-sibling::td[9]//a[@class="LinkDelete"]';
+    },
 }

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -988,7 +988,7 @@ Then(/^the Max Length and Audio-label fields will display$/, function () {
     chai.expect(audioLabelTextBoxDisplayStatus).to.be.true;
 })
 
-Then(/^these fields will be mandatory$/, function () {
+Then(/^the Max Length and Audio-label fields will be mandatory$/, function () {
     let maxLengthFieldLabelClass = action.getElementAttribute(campusDetailsPage.maxLengthFieldLabelOnManageCustomizedField,"class");
     chai.expect(maxLengthFieldLabelClass).to.includes("MandatoryLabel");
     let audioLabelFieldLabelClass = action.getElementAttribute(campusDetailsPage.audioLabelFieldLabelOnManageCustomizedField,"class");

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -975,3 +975,57 @@ Then(/^a tooltip will display with the following text: On Demand Telephone Inter
     let onDemandTelephoneInterpretingTextOnTooltipExistStatus = action.isExistingWait(campusDetailsPage.onDemandTelephoneInterpretingTextOnTooltip, 3000);
     chai.expect(onDemandTelephoneInterpretingTextOnTooltipExistStatus).to.be.true;
 })
+
+When(/^they select ‘Audible in ODTI’ checkbox$/, function () {
+    action.isVisibleWait(campusDetailsPage.audibleInODTICheckboxOnManageCustomizedField, 10000);
+    action.clickElement(campusDetailsPage.audibleInODTICheckboxOnManageCustomizedField);
+})
+
+Then(/^the Max Length and Audio-label fields will display$/, function () {
+    let maxLengthTextBoxDisplayStatus = action.isVisibleWait(campusDetailsPage.maxLengthTextBoxOnManageCustomizedField, 10000);
+    chai.expect(maxLengthTextBoxDisplayStatus).to.be.true;
+    let audioLabelTextBoxDisplayStatus = action.isVisibleWait(campusDetailsPage.audioLabelTextBoxOnManageCustomizedField, 10000);
+    chai.expect(audioLabelTextBoxDisplayStatus).to.be.true;
+})
+
+Then(/^these fields will be mandatory$/, function () {
+    let maxLengthFieldLabelClass = action.getElementAttribute(campusDetailsPage.maxLengthFieldLabelOnManageCustomizedField,"class");
+    chai.expect(maxLengthFieldLabelClass).to.includes("MandatoryLabel");
+    let audioLabelFieldLabelClass = action.getElementAttribute(campusDetailsPage.audioLabelFieldLabelOnManageCustomizedField,"class");
+    chai.expect(audioLabelFieldLabelClass).to.includes("MandatoryLabel");
+})
+
+When(/^the Admin enters Customised ODTI Field data "(.*)","(.*)","(.*)" in campus$/, function (fieldName, maxLength, audioLabel) {
+    GlobalData.CUSTOMISED_FIELD_NAME = fieldName + (Math.floor(Math.random() * 100000) + 1).toString();
+    action.enterValue(campusDetailsPage.fieldNameTextBoxOnManageCustomizedField,GlobalData.CUSTOMISED_FIELD_NAME);
+    action.clickElement(campusDetailsPage.freeTextRadioButtonOnManageCustomizedField);
+    action.isVisibleWait(campusDetailsPage.maxLengthTextBoxOnManageCustomizedField,20000);
+    action.enterValue(campusDetailsPage.maxLengthTextBoxOnManageCustomizedField,maxLength);
+    action.enterValue(campusDetailsPage.audioLabelTextBoxOnManageCustomizedField,audioLabel);
+})
+
+When(/^the Admin clicks the ‘Add’ button On Manage Customized Field$/, function () {
+    action.isVisibleWait(campusDetailsPage.addButtonOnManageCustomizedField,10000);
+    action.clickElement(campusDetailsPage.addButtonOnManageCustomizedField);
+})
+
+Then(/^the customised field will be created$/, function () {
+    let customisedFieldOverrideLink = $(campusDetailsPage.customisedFieldsOverrideLinkLocator.replace("<dynamic>",GlobalData.CUSTOMISED_FIELD_NAME));
+    let customisedFieldOverrideLinkDisplayStatus = action.isVisibleWait(customisedFieldOverrideLink,10000);
+    chai.expect(customisedFieldOverrideLinkDisplayStatus).to.be.true;
+})
+
+Then(/^there is a checkbox checked for the above custom field under the column Audible in ODTI$/, function () {
+    let customisedFieldsOverrideAudibleInODTICheckbox = $(campusDetailsPage.customisedFieldsOverrideAudibleInODTICheckboxLocator.replace("<dynamic>",GlobalData.CUSTOMISED_FIELD_NAME));
+    let customisedFieldsOverrideAudibleInODTICheckboxSelectedStatus = action.isSelectedWait(customisedFieldsOverrideAudibleInODTICheckbox,10000);
+    chai.expect(customisedFieldsOverrideAudibleInODTICheckboxSelectedStatus).to.be.true;
+})
+
+Then(/^the Customised ODTI Field is deleted in Campus$/, function () {
+    let customisedFieldDeleteIcon = $(campusDetailsPage.customisedFieldDeleteIconDynamicLocator.replace("<dynamic>", GlobalData.CUSTOMISED_FIELD_NAME));
+    action.isVisibleWait(customisedFieldDeleteIcon, 10000);
+    action.clickElement(customisedFieldDeleteIcon);
+    action.getAlertText();
+    action.acceptAlert();
+    action.isNotVisibleWait(customisedFieldDeleteIcon, 10000);
+})

--- a/test/utils/actions.js
+++ b/test/utils/actions.js
@@ -412,5 +412,24 @@ module.exports={
     {
         elt.click()
     },
+
+    /**
+     * Fetches and Returns The text of the currently displayed alert.
+     * @returns {string}
+     */
+    getAlertText()
+    {
+        let alertText = browser.getAlertText();
+        console.log("Alert Text is: "+alertText);
+        return alertText
+    },
+
+    /**
+     * Clicks OK on currently displayed alert and accepts the alert.
+     */
+    acceptAlert()
+    {
+        return browser.acceptAlert();
+    },
 }
 


### PR DESCRIPTION
- Added new locators in Campus Details page.
- Added reusable action methods to get alert text and accept alert.
- Added step methods to select ‘Audible in ODTI’ checkbox, to verify Max Length and Audio-label fields displayed and mandatory, to enter Customized ODTI Field data, to click the ‘Add’ button On Manage Customized Field, to verify Customized field is created, a checkbox checked for the custom field under the column Audible in ODTI and to delete Customized ODTI Field in Campus page.
- Automated scenarios 3 and 4 from LL-514 ticket - In progress.