### PR TITLE
Automated scenarios 5 and 6 from LL-514 ticket

### DIFF
--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -983,3 +983,47 @@ Feature: Campus Management features
   Examples:
    | username          | password  | campus id | customised field name | max length | audio label      |
    | LLAdmin@looped.in | Octopus@6 | 33124     | AutomationField       | 50         | automation label |
+
+  #LL-514 Scenario 5: Required fields not filled out
+ @LL-514 @CustomisedRequiredFieldsNotFilled
+ Scenario Outline: Required fields not filled out
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click add Customised Field
+  And they select ‘Audible in ODTI’ checkbox
+  And the Max Length and Audio-label fields will display
+  And there is no data in the Max Length and Audio-label fields
+  And the Admin enters Customised field name "<customised field name>" in campus
+  And the Admin clicks the ‘Add’ button On Manage Customized Field
+  Then the following inline error message will display: Required field!
+
+  Examples:
+   | username          | password  | campus id | customised field name |
+   | LLAdmin@looped.in | Octopus@6 | 33124     | AutomationField       |
+
+  #LL-514 Scenario 6: Editing the added custom field ‘Audible in ODTI’
+ @LL-514 @EditAddedCustomFieldODTI
+ Scenario Outline: Editing the added custom field ‘Audible in ODTI’
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click add Customised Field
+  And they select ‘Audible in ODTI’ checkbox
+  And the Max Length and Audio-label fields will display
+  And the Admin enters Customised ODTI Field data "<customised field name>","<max length>","<audio label>" in campus
+  And the Admin clicks the ‘Add’ button On Manage Customized Field
+  And the customised field will be created
+  And they select Customised field in the Campus page
+  And the Manage Customised Field modal is displayed
+  And I edit any data under Audible in ODTI "<max length edit>","<audio label edit>" in campus
+  And the Admin clicks the ‘Save’ button On Manage Customized Field
+  And they select Customised field in the Campus page
+  Then the custom field is updated with latest values "<max length edit>","<audio label edit>"
+  And I click on delete icon on Customised ODTI Field in Campus
+
+  Examples:
+   | username          | password  | campus id | customised field name | max length | audio label      | max length edit | audio label edit  |
+   | LLAdmin@looped.in | Octopus@6 | 33124     | AutomationField       | 50         | automation label | 60              | automation label2 |

--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -906,6 +906,10 @@ Feature: Campus Management features
   And I search for contract title "<contract title>"
   And I click the contract link "<contract title>" from search results
   And the Customised ODTI Field is removed
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And I click on delete icon on Customised ODTI Field in Campus
 
   Examples:
    | username          | password  | contract title                                   | customised field name | max length | audio label      | campus id |
@@ -974,7 +978,7 @@ Feature: Campus Management features
   And the Admin clicks the ‘Add’ button On Manage Customized Field
   Then the customised field will be created
   And there is a checkbox checked for the above custom field under the column Audible in ODTI
-  And the Customised ODTI Field is deleted in Campus
+  And I click on delete icon on Customised ODTI Field in Campus
 
   Examples:
    | username          | password  | campus id | customised field name | max length | audio label      |

--- a/test/pages/CampusDetails/CampusDetails.js
+++ b/test/pages/CampusDetails/CampusDetails.js
@@ -534,4 +534,16 @@ module.exports ={
     get customisedFieldDeleteIconDynamicLocator() {
         return '//a[text()="<dynamic>"]/parent::div/parent::div/parent::td/following-sibling::td[9]//a[@class="LinkDelete"]';
     },
+
+    get maxLengthRequiredFieldMessageOnManageCustomizedField() {
+        return $('//input[contains(@id,"CustomizedFields_ODTIInputMaxlength")]/following-sibling::span[text()="Required field!"]');
+    },
+
+    get audioLabelRequiredFieldMessageOnManageCustomizedField() {
+        return $('//input[contains(@id,"CustomizedFields_ODTIAudioName")]/following-sibling::span[text()="Required field!"]');
+    },
+
+    get saveButtonOnManageCustomizedField() {
+        return $('//input[@value="Save" and (contains(@id,"AddModal"))]');
+    },
 }

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -1029,3 +1029,51 @@ Then(/^I click on delete icon on Customised ODTI Field in Campus$/, function () 
     action.acceptAlert();
     action.isNotVisibleWait(customisedFieldDeleteIcon, 10000);
 })
+
+Then(/^there is no data in the Max Length and Audio-label fields$/, function () {
+    let maxLengthFieldLabelClass = action.getElementValue(campusDetailsPage.maxLengthTextBoxOnManageCustomizedField);
+    chai.expect(maxLengthFieldLabelClass).to.includes("0");
+    let audioLabelFieldLabelClass = action.getElementValue(campusDetailsPage.audioLabelTextBoxOnManageCustomizedField);
+    chai.expect(audioLabelFieldLabelClass).to.includes("");
+})
+
+When(/^the Admin enters Customised field name "(.*)" in campus$/, function (fieldName) {
+    GlobalData.CUSTOMISED_FIELD_NAME = fieldName + (Math.floor(Math.random() * 100000) + 1).toString();
+    action.enterValue(campusDetailsPage.fieldNameTextBoxOnManageCustomizedField,GlobalData.CUSTOMISED_FIELD_NAME);
+})
+
+Then(/^the following inline error message will display: Required field!$/, function () {
+    let maxLengthRequiredFieldMessageDisplayStatus = action.isVisibleWait(campusDetailsPage.maxLengthRequiredFieldMessageOnManageCustomizedField, 10000);
+    chai.expect(maxLengthRequiredFieldMessageDisplayStatus).to.be.true;
+    let audioLabelRequiredFieldMessageDisplayStatus = action.isVisibleWait(campusDetailsPage.audioLabelRequiredFieldMessageOnManageCustomizedField, 10000);
+    chai.expect(audioLabelRequiredFieldMessageDisplayStatus).to.be.true;
+})
+
+When(/^they select Customised field in the Campus page$/, function () {
+    let customisedFieldOverrideLink = $(campusDetailsPage.customisedFieldsOverrideLinkLocator.replace("<dynamic>",GlobalData.CUSTOMISED_FIELD_NAME));
+    action.clickElement(customisedFieldOverrideLink);
+})
+
+When(/^Manage Customized Field popup appears$/, function () {
+    let customisedFieldOverrideLink = $(campusDetailsPage.customisedFieldsOverrideLinkLocator.replace("<dynamic>",GlobalData.CUSTOMISED_FIELD_NAME));
+    action.clickElement(customisedFieldOverrideLink);
+})
+
+When(/^I edit any data under Audible in ODTI "(.*)","(.*)" in campus$/, function (maxLength, audioLabel) {
+    action.clickElement(campusDetailsPage.freeTextRadioButtonOnManageCustomizedField);
+    action.isVisibleWait(campusDetailsPage.maxLengthTextBoxOnManageCustomizedField,20000);
+    action.enterValue(campusDetailsPage.maxLengthTextBoxOnManageCustomizedField,maxLength);
+    action.enterValue(campusDetailsPage.audioLabelTextBoxOnManageCustomizedField,audioLabel);
+})
+
+When(/^the Admin clicks the ‘Save’ button On Manage Customized Field$/, function () {
+    action.isVisibleWait(campusDetailsPage.saveButtonOnManageCustomizedField,10000);
+    action.clickElement(campusDetailsPage.saveButtonOnManageCustomizedField);
+})
+
+Then(/^the custom field is updated with latest values "(.*)","(.*)"$/, function (maxLength, audioLabel) {
+    let maxLengthFieldLabelClass = action.getElementValue(campusDetailsPage.maxLengthTextBoxOnManageCustomizedField);
+    chai.expect(maxLengthFieldLabelClass).to.includes(maxLength);
+    let audioLabelFieldLabelClass = action.getElementValue(campusDetailsPage.audioLabelTextBoxOnManageCustomizedField);
+    chai.expect(audioLabelFieldLabelClass).to.includes(audioLabel);
+})

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -1021,7 +1021,7 @@ Then(/^there is a checkbox checked for the above custom field under the column A
     chai.expect(customisedFieldsOverrideAudibleInODTICheckboxSelectedStatus).to.be.true;
 })
 
-Then(/^the Customised ODTI Field is deleted in Campus$/, function () {
+Then(/^I click on delete icon on Customised ODTI Field in Campus$/, function () {
     let customisedFieldDeleteIcon = $(campusDetailsPage.customisedFieldDeleteIconDynamicLocator.replace("<dynamic>", GlobalData.CUSTOMISED_FIELD_NAME));
     action.isVisibleWait(customisedFieldDeleteIcon, 10000);
     action.clickElement(customisedFieldDeleteIcon);


### PR DESCRIPTION
- Added new locators in Campus Details page.
- Added step methods to enter field name, select added field, edit any data under Audible in ODTI, click the ‘Save’ button On Manage Customized Field and to verify Manage Customized Field popup appears, no data in the Max Length and Audio-label fields, inline error message Required field is displayed, custom field is updated with latest values.
- Updated steps in scenario 1 from LL-514 ticket.
- Automated scenarios 5 and 6 from LL-514 ticket.