### PR TITLE
Automated scenarios 7 from LL-514 and 6 from LL-489

### DIFF
--- a/test/features/AccountManagement/CampusManagement.feature
+++ b/test/features/AccountManagement/CampusManagement.feature
@@ -1027,3 +1027,23 @@ Feature: Campus Management features
   Examples:
    | username          | password  | campus id | customised field name | max length | audio label      | max length edit | audio label edit  |
    | LLAdmin@looped.in | Octopus@6 | 33124     | AutomationField       | 50         | automation label | 60              | automation label2 |
+
+  #LL-514 Scenario 7: Deleting the added custom field Audible in ODTI
+ @LL-514 @DeleteCustomField
+ Scenario Outline: Deleting the added custom field Audible in ODTI
+  When I login with "<username>" and "<password>"
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they click add Customised Field
+  And they select ‘Audible in ODTI’ checkbox
+  And the Max Length and Audio-label fields will display
+  And the Admin enters Customised ODTI Field data "<customised field name>","<max length>","<audio label>" in campus
+  And the Admin clicks the ‘Add’ button On Manage Customized Field
+  And the customised field will be created
+  And I click on delete icon on Customised ODTI Field in Campus
+  Then the custom field is deleted in campus
+
+  Examples:
+   | username          | password  | campus id | customised field name | max length | audio label      |
+   | LLAdmin@looped.in | Octopus@6 | 33124     | AutomationField       | 50         | automation label |

--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -82,3 +82,18 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | configuration toggles                                                                                      | campus pin |
       | LLAdmin@looped.in | Octopus@6 | Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number | 33124      |
+
+    #LL-489: Scenario 6: User is unable to edit the Campus pin and Service type in the Edit Campus Configuration
+  @LL-489 @UnableToEditCampusPinServiceType
+  Scenario Outline: User is unable to edit the Campus pin and Service type in the Edit Campus Configuration
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And the Admin is on the Edit Campus Configuration screen of Campus "<campus>"
+    And the Edit Campus Configuration Page is displayed
+    Then the Service Type and Campus pin fields are read only
+    And user cannot update the Service Type and Campus pin fields values
+
+    Examples:
+      | username          | password  | campus                  |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |

--- a/test/pages/ODTI_UI/EditCampusConfiguration.js
+++ b/test/pages/ODTI_UI/EditCampusConfiguration.js
@@ -11,6 +11,14 @@ module.exports = {
 
     get savedConfiguration() {
         return $('//div[contains(@id,"DIDConfigurationForm")]');
-    }
+    },
+
+    get TIServiceTypeDropdownDisabled() {
+        return $('//select[contains(@id,"TIServiceType") and @disabled]');
+    },
+
+    get campusPinInputTextBoxReadOnly() {
+        return $('//input[contains(@id,"DIDConfiguration_CampusBillToId") and @readonly]');
+    },
 
 }

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -1077,3 +1077,9 @@ Then(/^the custom field is updated with latest values "(.*)","(.*)"$/, function 
     let audioLabelFieldLabelClass = action.getElementValue(campusDetailsPage.audioLabelTextBoxOnManageCustomizedField);
     chai.expect(audioLabelFieldLabelClass).to.includes(audioLabel);
 })
+
+Then(/^the custom field is deleted in campus$/, function () {
+    let customisedFieldOverrideLink = $(campusDetailsPage.customisedFieldsOverrideLinkLocator.replace("<dynamic>",GlobalData.CUSTOMISED_FIELD_NAME));
+    let customisedFieldOverrideLinkDisplayStatus = action.isVisibleWait(customisedFieldOverrideLink,1000);
+    chai.expect(customisedFieldOverrideLinkDisplayStatus).to.be.false;
+})

--- a/test/stepdefinition/ODTI_UI/EditCampusConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/EditCampusConfigurationSteps.js
@@ -14,3 +14,17 @@ Then(/^the saved configuration is displayed$/, function () {
     let savedConfigurationDisplayStatus = action.isVisibleWait(editCampusConfigurationPage.savedConfiguration, 10000);
     chai.expect(savedConfigurationDisplayStatus).to.be.true;
 })
+
+Then(/^the Service Type and Campus pin fields are read only$/, function () {
+    let TIServiceTypeDropdownDisabledDisplayStatus = action.isVisibleWait(editCampusConfigurationPage.TIServiceTypeDropdownDisabled, 10000);
+    chai.expect(TIServiceTypeDropdownDisabledDisplayStatus).to.be.true;
+    let campusPinInputReadOnlyDisplayStatus = action.isVisibleWait(editCampusConfigurationPage.campusPinInputTextBoxReadOnly, 10000);
+    chai.expect(campusPinInputReadOnlyDisplayStatus).to.be.true;
+})
+
+Then(/^user cannot update the Service Type and Campus pin fields values$/, function () {
+    let TIServiceTypeDropdownClickableStatus = action.isClickableWait(editCampusConfigurationPage.TIServiceTypeDropdownDisabled, 1000);
+    chai.expect(TIServiceTypeDropdownClickableStatus).to.be.false;
+    let campusPinInputReadOnlyClickableStatus = action.isClickableWait(editCampusConfigurationPage.campusPinInputTextBoxReadOnly, 1000);
+    chai.expect(campusPinInputReadOnlyClickableStatus).to.be.false;
+})


### PR DESCRIPTION
- Added new locators in Edit Campus configuration page.
- Added step methods to delete and verify the custom field is deleted in campus, to verify the Service Type, Campus pin fields are read only and user cannot update the Service Type and Campus pin fields values in Edit Campus Configuration page.
- Automated scenario 7 from LL-514 ticket - Completed.
- Automated scenario 6 from LL-489 ticket - In progress.