### PR TITLE
Automated scenarios 7 and 8 from LL-489 ticket

### DIFF
--- a/test/features/AccountManagement/AccountManagement.feature
+++ b/test/features/AccountManagement/AccountManagement.feature
@@ -1,4 +1,4 @@
-@Admin
+@AccountManagement
 Feature: Account Management features
 
   Background: Load the Loopedin login page

--- a/test/features/ODTI/ODTIInterpretersCSO.feature
+++ b/test/features/ODTI/ODTIInterpretersCSO.feature
@@ -1,4 +1,4 @@
-@ODTIJobsCBO
+@ODTIInterpretersCSO
 Feature: ODTI Interpreters CSO features
 
   Background: Load the Loopedin login page

--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -1,4 +1,4 @@
-@ODTIJobsCBO
+@ODTIJobsCSO
 Feature: ODTI Jobs CSO features
 
   Background: Load the Loopedin login page

--- a/test/features/ODTI/ODTIJobsFinance.feature
+++ b/test/features/ODTI/ODTIJobsFinance.feature
@@ -1,4 +1,4 @@
-@ODTIJobsCBO
+@ODTIJobsFinance
 Feature: ODTI Jobs Finance features
 
   Background: Load the Loopedin login page

--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -119,3 +119,17 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | campus                  | configuration toggles                                                                                      | configuration toggles updated                                                                                                      |
       | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD | Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number | Configuration Is Active,Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number |
+
+    #LL-489: Scenario 8: User can perform search using DID or Campus Pin
+  @LL-489 @SearchUsingDIDOrCampusPin
+  Scenario Outline: User can perform search using DID or Campus Pin
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And user searches for Campus name or DID "<campus name>" by entering valid data in the search field
+    And clicks on Search button in DID Campus configuration
+    Then the correct search results campus "<campus>" are displayed
+
+    Examples:
+      | username          | password  | campus                  | campus name     |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD | Contoso Pty LTD |

--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -1,4 +1,4 @@
-@ODTIJobsCBO
+@CampusConfiguration
 Feature: ODTI_UI Campus Configuration features
 
   Background: Load the ODTI DID Configurations page

--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -97,3 +97,25 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | campus                  |
       | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |
+
+    #LL-489: Scenario 7: User is able to edit configuration settings in the Edit Campus Configuration
+  @LL-489 @EditConfigurationSettings
+  Scenario Outline: User is able to edit configuration settings in the Edit Campus Configuration
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And the Admin is on the Edit Campus Configuration screen of Campus "<campus>"
+    And the Edit Campus Configuration Page is displayed
+    And make Configuration Is Active to Active or Inactive
+    And update the options settings under Configuration section "<configuration toggles>"
+    And clicks on Save button in Edit Campus Configuration
+    And the Admin is on the Edit Campus Configuration screen of Campus "<campus>"
+    And the Edit Campus Configuration Page is displayed
+    Then the campus details "<configuration toggles updated>" are updated
+    And make Configuration Is Active to Active or Inactive
+    And update the options settings under Configuration section "<configuration toggles>"
+    And clicks on Save button in Edit Campus Configuration
+
+    Examples:
+      | username          | password  | campus                  | configuration toggles                                                                                      | configuration toggles updated                                                                                                      |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD | Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number | Configuration Is Active,Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number |

--- a/test/pages/ODTI_UI/DIDConfigurations.js
+++ b/test/pages/ODTI_UI/DIDConfigurations.js
@@ -23,5 +23,21 @@ module.exports = {
 
     get duplicateCampusConfigurationLinksLocator() {
         return '//a[text()="<dynamicCampusPin>"]/parent::td/following-sibling::td/a[text()="Duplicate"]';
-    }
+    },
+
+    get searchByDIDOrCampusNameTextBox() {
+        return $('//input[contains(@id,"SearchInput2")]');
+    },
+
+    get searchButton() {
+        return $('//input[contains(@id,"SearchInput2")]/following-sibling::input[@value="Search"]')
+    },
+
+    get tableRowsCount() {
+        return $$('//input[contains(@id,"SearchInput2")]/parent::div/parent::div//tbody//tr').length;
+    },
+
+    get campusValueInTable() {
+        return '//input[contains(@id,"SearchInput2")]/parent::div/parent::div//tbody//tr[<dynamicRowNumber>]/td[1]';
+    },
 }

--- a/test/pages/ODTI_UI/EditCampusConfiguration.js
+++ b/test/pages/ODTI_UI/EditCampusConfiguration.js
@@ -21,4 +21,15 @@ module.exports = {
         return $('//input[contains(@id,"DIDConfiguration_CampusBillToId") and @readonly]');
     },
 
+    get configurationActiveToggle() {
+        return $('//label[text()="Configuration Is Active"]/parent::div//input');
+    },
+
+    get configurationToggleCheckboxLocator() {
+        return '//label[text()="<dynamic>"]/parent::div//input';
+    },
+
+    get saveButton() {
+        return $('//input[@value="Save"]');
+    }
 }

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -37,3 +37,23 @@ Then(/^the admin is navigated back to the configuration list screen$/, function 
     let pageTitleActual = action.getPageTitle();
     chai.expect(pageTitleActual).to.includes("DID Configurations");
 })
+
+When(/^user searches for Campus name or DID "(.*)" by entering valid data in the search field$/, function (DIDOrCampusName) {
+    action.isVisibleWait(DIDConfigurationsPage.searchByDIDOrCampusNameTextBox, 10000);
+    action.enterValue(DIDConfigurationsPage.searchByDIDOrCampusNameTextBox, DIDOrCampusName);
+})
+
+When(/^clicks on Search button in DID Campus configuration$/, function () {
+    action.isVisibleWait(DIDConfigurationsPage.searchButton, 10000);
+    action.clickElement(DIDConfigurationsPage.searchButton);
+    action.isNotVisibleWait(DIDConfigurationsPage.searchButton, 2000);
+})
+
+Then(/^the correct search results campus "(.*)" are displayed$/, function (expectedCampus) {
+    let tableRowsCount = DIDConfigurationsPage.tableRowsCount;
+    for (let row = 1; row <= tableRowsCount; row++) {
+        let campusValueElement = $(DIDConfigurationsPage.campusValueInTable.replace("<dynamicRowNumber>", row.toString()));
+        let campusValueActual = action.getElementText(campusValueElement);
+        chai.expect(campusValueActual).to.equal(expectedCampus);
+    }
+})

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -12,6 +12,7 @@ When(/^the Admin is on the Edit Campus Configuration screen of Campus "(.*)"$/, 
     let editCampusConfigurationLinksCount = $$(DIDConfigurationsPage.editCampusConfigurationLinksLocator.replace("<dynamicCampusPin>", campusPin)).length;
     for (let index = 1; index <= editCampusConfigurationLinksCount; index++) {
         let editCampusConfigurationLink = $(DIDConfigurationsPage.editCampusConfigurationLinkLocator.replace("<dynamicCampusPin>", campusPin).replace("<dynamicIndex>", index.toString()));
+        action.isNotVisibleWait(editCampusConfigurationLink, 2000);
         let editLinkVisible = action.isVisibleWait(editCampusConfigurationLink, 1000);
         if (editLinkVisible) {
             action.clickElement(editCampusConfigurationLink);

--- a/test/stepdefinition/ODTI_UI/EditCampusConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/EditCampusConfigurationSteps.js
@@ -28,3 +28,34 @@ Then(/^user cannot update the Service Type and Campus pin fields values$/, funct
     let campusPinInputReadOnlyClickableStatus = action.isClickableWait(editCampusConfigurationPage.campusPinInputTextBoxReadOnly, 1000);
     chai.expect(campusPinInputReadOnlyClickableStatus).to.be.false;
 })
+
+When(/^make Configuration Is Active to Active or Inactive$/, function () {
+    action.isExistingWait(editCampusConfigurationPage.configurationActiveToggle, 10000);
+    action.clickWithOutWait(editCampusConfigurationPage.configurationActiveToggle);
+})
+
+When(/^update the options settings under Configuration section "(.*)"$/, function (configurationToggles) {
+    let configurationTogglesList = configurationToggles.split(",")
+    for (let index = 0; index < configurationTogglesList.length; index++) {
+        let configurationToggleElement = $(editCampusConfigurationPage.configurationToggleCheckboxLocator.replace("<dynamic>", configurationTogglesList[index]));
+        action.isNotVisibleWait(configurationToggleElement, 2000);
+        action.isExistingWait(configurationToggleElement, 10000);
+        action.clickWithOutWait(configurationToggleElement);
+    }
+})
+
+When(/^clicks on Save button in Edit Campus Configuration$/, function () {
+    action.isNotVisibleWait(editCampusConfigurationPage.saveButton, 2000);
+    action.isVisibleWait(editCampusConfigurationPage.saveButton, 10000);
+    action.clickElement(editCampusConfigurationPage.saveButton);
+    action.isNotVisibleWait(editCampusConfigurationPage.saveButton, 2000);
+})
+
+Then(/^the campus details "(.*)" are updated$/, function (configurationToggles) {
+    let configurationTogglesList = configurationToggles.split(",")
+    for (let index = 0; index < configurationTogglesList.length; index++) {
+        let configurationToggleElement = $(editCampusConfigurationPage.configurationToggleCheckboxLocator.replace("<dynamic>", configurationTogglesList[index]));
+        let toggleOriginalValue = action.getElementAttribute(configurationToggleElement,"origvalue");
+        chai.expect(toggleOriginalValue).to.equal("false");
+    }
+})


### PR DESCRIPTION
- Updated tags in few feature files.
- Added new locators in Edit Campus configuration page and DID Configurations page.
- Added step methods to make Configuration Is Active to Active or Inactive, update the options settings under Configuration section, click on Save button in Edit Campus Configuration and to verify the campus details are updated, to search for Campus name or DID, click on Search button, verify the correct search results campus are displayed in DID Configuration page..
- Automated scenarios 7 and 8 from LL-489 ticket.