### PR TITLE
Automated scenario 9 from LL-489 ticket

### DIFF
--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -133,3 +133,17 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | campus                  | campus name     |
       | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD | Contoso Pty LTD |
+
+    #LL-489: Scenario 9: User can perform search using Service Type
+  @LL-489 @SearchUsingServiceType
+  Scenario Outline: User can perform search using Service Type
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And user selects any Service Type "<service type>" from the dropdown
+    And clicks on Search button in DID Campus configuration
+    Then the correct search results service type "<service type>" are displayed
+
+    Examples:
+      | username          | password  | service type |
+      | LLAdmin@looped.in | Octopus@6 | General TI   |

--- a/test/pages/ODTI_UI/DIDConfigurations.js
+++ b/test/pages/ODTI_UI/DIDConfigurations.js
@@ -40,4 +40,20 @@ module.exports = {
     get campusValueInTable() {
         return '//input[contains(@id,"SearchInput2")]/parent::div/parent::div//tbody//tr[<dynamicRowNumber>]/td[1]';
     },
+
+    get serviceTypeDropdown() {
+        return $('//input[contains(@id,"SearchInput2")]/following-sibling::select');
+    },
+
+    get serviceTypeValueInTable() {
+        return '//input[contains(@id,"SearchInput2")]/parent::div/parent::div//tbody//tr[<dynamicRowNumber>]/td[2]';
+    },
+
+    get didConfigurationTab() {
+        return $('//div[@role="tab" and text()="DID Configuration"]');
+    },
+
+    get didConfigurationTable() {
+        return $('//table[contains(@id,"DIDConfigurationTable")]')
+    },
 }

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -57,3 +57,27 @@ Then(/^the correct search results campus "(.*)" are displayed$/, function (expec
         chai.expect(campusValueActual).to.equal(expectedCampus);
     }
 })
+
+When(/^user selects any Service Type "(.*)" from the dropdown$/, function (serviceType) {
+    action.isVisibleWait(DIDConfigurationsPage.serviceTypeDropdown, 10000);
+    action.selectTextFromDropdown(DIDConfigurationsPage.serviceTypeDropdown, serviceType);
+})
+
+Then(/^the correct search results service type "(.*)" are displayed$/, function (expectedServiceType) {
+    let tableRowsCount = DIDConfigurationsPage.tableRowsCount;
+    for (let row = 1; row <= tableRowsCount; row++) {
+        let serviceTypeElement = $(DIDConfigurationsPage.serviceTypeValueInTable.replace("<dynamicRowNumber>", row.toString()));
+        let serviceTypeActual = action.getElementText(serviceTypeElement);
+        chai.expect(serviceTypeActual).to.equal(expectedServiceType);
+    }
+})
+
+When(/^the Admin is on the DID Configurations Tab$/, function () {
+    action.isVisibleWait(DIDConfigurationsPage.didConfigurationTab, 10000);
+    action.clickElement(DIDConfigurationsPage.didConfigurationTab);
+})
+
+When(/^the user sees a table that lists all the DID configurations defined$/, function () {
+    let didConfigurationTableDisplayStatus = action.isVisibleWait(DIDConfigurationsPage.didConfigurationTable, 10000);
+    chai.expect(didConfigurationTableDisplayStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in DID Configurations page.
- Added step methods to select any Service Type from the dropdown, to verify the search results are correct for service type, to navigate to DID Configurations Tab and to verify table that lists all the DID configurations defined.
- Automated scenario 9 from LL-489 ticket.
- Started automating Scenario 1a from LL-515 ticket - In progress.