### PR TITLE
Automated scenario 1a and 1b from LL-515 ticket

### DIFF
--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -147,3 +147,31 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  | service type |
       | LLAdmin@looped.in | Octopus@6 | General TI   |
+
+    #LL-515: Scenario 1a - Display List of DID Configurations
+  @LL-515 @DisplayListDIDConfigurations
+  Scenario Outline: Display List of DID Configurations
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    Then the user sees a table that lists all the DID configurations defined
+    And each row shows the "<table headers>" and "<table row links>" links under DID Configuration tab
+    And the user sees a New Configuration button under DID Configuration tab
+
+    Examples:
+      | username          | password  | table headers                     | table row links |
+      | LLAdmin@looped.in | Octopus@6 | DID,Service Type,Campus,Is Active | Edit,Duplicate  |
+
+    #LL-515: Scenario 1b - Display List of Campus Configurations
+  @LL-515 @DisplayListCampusConfigurations
+  Scenario Outline: Display List of Campus Configurations
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    Then the user sees a table that lists all the Campus configurations defined
+    And each row shows the "<table headers>" and "<table row links>" links under Campus Configuration tab
+    And the user sees a New Configuration button under Campus Configuration tab
+
+    Examples:
+      | username          | password  | table headers                     | table row links |
+      | LLAdmin@looped.in | Octopus@6 | Campus,Service Type,DID,Is Active | Edit,Duplicate  |

--- a/test/pages/ODTI_UI/DIDConfigurations.js
+++ b/test/pages/ODTI_UI/DIDConfigurations.js
@@ -56,4 +56,28 @@ module.exports = {
     get didConfigurationTable() {
         return $('//table[contains(@id,"DIDConfigurationTable")]')
     },
+
+    get didConfigurationTableHeaderRow() {
+        return $('//table[contains(@id,"DIDConfigurationTable")]/thead/tr')
+    },
+
+    get didConfigurationTableEditAndDuplicateLinks() {
+        return $('//table[contains(@id,"DIDConfigurationTable")]/tbody/tr[1]//a[not(contains(text(),"-"))]/parent::td');
+    },
+
+    get newConfigurationButtonUnderDIDConfiguration() {
+        return $('//input[@value="New Configuration" and contains(@onclick,"DIDConfiguration")]');
+    },
+
+    get campusConfigurationTable() {
+        return $('//table[contains(@id,"CampusConfigurationTable")]')
+    },
+
+    get campusConfigurationTableHeaderRow() {
+        return $('//table[contains(@id,"CampusConfigurationTable")]/thead/tr')
+    },
+
+    get campusConfigurationTableEditAndDuplicateLinks() {
+        return $('//table[contains(@id,"CampusConfigurationTable")]/tbody/tr[1]//a[not(contains(text(),"-"))]/parent::td');
+    },
 }

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -77,7 +77,48 @@ When(/^the Admin is on the DID Configurations Tab$/, function () {
     action.clickElement(DIDConfigurationsPage.didConfigurationTab);
 })
 
-When(/^the user sees a table that lists all the DID configurations defined$/, function () {
+Then(/^the user sees a table that lists all the DID configurations defined$/, function () {
     let didConfigurationTableDisplayStatus = action.isVisibleWait(DIDConfigurationsPage.didConfigurationTable, 10000);
     chai.expect(didConfigurationTableDisplayStatus).to.be.true;
+})
+
+Then(/^each row shows the "(.*)" and "(.*)" links under DID Configuration tab$/, function (expectedHeaders,expectedLinks) {
+    let didConfigurationTableHeaderRowText = action.getElementText(DIDConfigurationsPage.didConfigurationTableHeaderRow, 10000);
+    let expectedHeadersList = expectedHeaders.split(",")
+    for (let i=0; i<expectedHeadersList.length;i++) {
+        chai.expect(didConfigurationTableHeaderRowText).to.includes(expectedHeadersList[i]);
+    }
+    let didConfigurationTableEditAndDuplicateLinks = action.getElementText(DIDConfigurationsPage.didConfigurationTableEditAndDuplicateLinks, 10000);
+    let expectedLinksList = expectedLinks.split(",")
+    for (let i=0; i<expectedLinksList.length;i++) {
+        chai.expect(didConfigurationTableEditAndDuplicateLinks).to.includes(expectedLinksList[i]);
+    }
+})
+
+Then(/^the user sees a New Configuration button under DID Configuration tab$/, function () {
+    let newConfigurationButtonDisplayStatus = action.isVisibleWait(DIDConfigurationsPage.newConfigurationButtonUnderDIDConfiguration, 10000);
+    chai.expect(newConfigurationButtonDisplayStatus).to.be.true;
+})
+
+Then(/^the user sees a table that lists all the Campus configurations defined$/, function () {
+    let campusConfigurationTableDisplayStatus = action.isVisibleWait(DIDConfigurationsPage.campusConfigurationTable, 10000);
+    chai.expect(campusConfigurationTableDisplayStatus).to.be.true;
+})
+
+Then(/^each row shows the "(.*)" and "(.*)" links under Campus Configuration tab$/, function (expectedHeaders,expectedLinks) {
+    let campusConfigurationTableHeaderRowText = action.getElementText(DIDConfigurationsPage.campusConfigurationTableHeaderRow, 10000);
+    let expectedHeadersList = expectedHeaders.split(",")
+    for (let i=0; i<expectedHeadersList.length;i++) {
+        chai.expect(campusConfigurationTableHeaderRowText).to.includes(expectedHeadersList[i]);
+    }
+    let campusConfigurationTableEditAndDuplicateLinks = action.getElementText(DIDConfigurationsPage.campusConfigurationTableEditAndDuplicateLinks, 10000);
+    let expectedLinksList = expectedLinks.split(",")
+    for (let i=0; i<expectedLinksList.length;i++) {
+        chai.expect(campusConfigurationTableEditAndDuplicateLinks).to.includes(expectedLinksList[i]);
+    }
+})
+
+Then(/^the user sees a New Configuration button under Campus Configuration tab$/, function () {
+    let newConfigurationButtonDisplayStatus = action.isVisibleWait(DIDConfigurationsPage.newConfigurationButtonUnderCampusConfiguration, 10000);
+    chai.expect(newConfigurationButtonDisplayStatus).to.be.true;
 })


### PR DESCRIPTION
- Added new locators in DID Configurations page.
- Added step methods to verify table that lists all the Campus configurations defined, each row shows the headers and links, New Configuration buttons under both DID Configuration tab and Campus Configuration tab.
- Automated scenario 1a and 1b from LL-515 ticket.