### PR TITLE
Automated scenario 3a and 3b from LL-515 ticket

### DIFF
--- a/test/features/ODTI_UI/CampusConfiguration.feature
+++ b/test/features/ODTI_UI/CampusConfiguration.feature
@@ -203,3 +203,31 @@ Feature: ODTI_UI Campus Configuration features
     Examples:
       | username          | password  |
       | LLAdmin@looped.in | Octopus@6 |
+
+    #LL-515: Scenario 3a - Clicking existing configuration Edit link
+  @LL-515 @DIDConfigurationEditLink
+  Scenario Outline: Clicking existing DID configuration Edit link
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the Admin is on the Edit DID Configuration screen of Campus "<campus>"
+    Then the user is navigated to the Edit DID Configuration screen
+    And the existing configuration is shown
+
+    Examples:
+      | username          | password  | campus                  |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |
+
+    #LL-515: Scenario 3b - Clicking existing configuration Edit link
+  @LL-489 @CampusConfigurationEditLink
+  Scenario Outline: Clicking existing Campus configuration Edit link
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin clicks on Campus Configuration tab
+    And the Admin is on the Edit Campus Configuration screen of Campus "<campus>"
+    Then the Edit Campus Configuration Page is displayed
+    And the saved configuration is displayed
+
+    Examples:
+      | username          | password  | campus                  |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |

--- a/test/pages/ODTI_UI/DIDConfigurations.js
+++ b/test/pages/ODTI_UI/DIDConfigurations.js
@@ -80,4 +80,12 @@ module.exports = {
     get campusConfigurationTableEditAndDuplicateLinks() {
         return $('//table[contains(@id,"CampusConfigurationTable")]/tbody/tr[1]//a[not(contains(text(),"-"))]/parent::td');
     },
+
+    get editDIDConfigurationLinkLocator() {
+        return '(//a[text()="<dynamicCampusPin>"]/parent::td/following-sibling::td/a[text()="Edit"])[<dynamicIndex>]';
+    },
+
+    get editDIDConfigurationLinksLocator() {
+        return '//a[text()="<dynamicCampusPin>"]/parent::td/following-sibling::td/a[text()="Edit"]';
+    },
 }

--- a/test/pages/ODTI_UI/EditDIDConfiguration.js
+++ b/test/pages/ODTI_UI/EditDIDConfiguration.js
@@ -1,0 +1,7 @@
+
+module.exports = {
+
+    get existingConfiguration() {
+        return $('//div[contains(@id,"DIDConfigurationForm")]');
+    },
+}

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -132,3 +132,16 @@ When(/^the user has clicked on the New Configuration button under Campus Configu
     action.isVisibleWait(DIDConfigurationsPage.newConfigurationButtonUnderCampusConfiguration, 10000);
     action.clickElement(DIDConfigurationsPage.newConfigurationButtonUnderCampusConfiguration);
 })
+
+When(/^the Admin is on the Edit DID Configuration screen of Campus "(.*)"$/, function (campusPin) {
+    let editDIDConfigurationLinksCount = $$(DIDConfigurationsPage.editDIDConfigurationLinksLocator.replace("<dynamicCampusPin>", campusPin)).length;
+    for (let index = 1; index <= editDIDConfigurationLinksCount; index++) {
+        let editDIDConfigurationLink = $(DIDConfigurationsPage.editDIDConfigurationLinkLocator.replace("<dynamicCampusPin>", campusPin).replace("<dynamicIndex>", index.toString()));
+        action.isNotVisibleWait(editDIDConfigurationLink, 2000);
+        let editLinkVisible = action.isVisibleWait(editDIDConfigurationLink, 1000);
+        if (editLinkVisible) {
+            action.clickElement(editDIDConfigurationLink);
+            break;
+        }
+    }
+})

--- a/test/stepdefinition/ODTI_UI/EditDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/EditDIDConfigurationSteps.js
@@ -1,0 +1,9 @@
+Then(/^the user is navigated to the Edit DID Configuration screen$/, function () {
+    let pageTitleActual = action.getPageTitle();
+    chai.expect(pageTitleActual).to.equal("Edit DID Configuration");
+})
+
+Then(/^the existing configuration is shown$/, function () {
+    let existingConfigurationDisplayStatus = action.isVisibleWait(editDIDConfigurationPage.existingConfiguration, 10000);
+    chai.expect(existingConfigurationDisplayStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in DID Configurations and Edit DID Configuration pages.
- Added step methods to verify the Admin is on the Edit DID Configuration screen of Campus, user is navigated to the Edit DID Configuration screen and the existing configuration is shown.
- Automated scenario 3a and 3b from LL-515 ticket.