### PR TITLE
Automated scenarios 2 and 3a from LL-577 ticket

### DIFF
--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -43,3 +43,35 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  | campus                  |
       | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |
+
+
+    #LL-577: Scenario 2 - Entering a Campus PIN
+  @LL-577 @DIDODTIConfigurationCampusPin
+  Scenario Outline: Entering a Campus PIN
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And has selected the TI Service Type "<TI Service Type>" in DID configuration
+    And has typed in a Campus PIN "<campus pin>" in DID configuration
+    Then the PIN is searched in DID configuration
+    And the Campus name "<campus name>" is displayed below the input box in DID configuration
+
+    Examples:
+      | username          | password  | campus pin | TI Service Type | campus name     |
+      | LLAdmin@looped.in | Octopus@6 | 29449      | NES Initiated   | Contoso Pty LTD |
+
+    #LL-577: Scenario 3a - Selecting a Service Type
+  @LL-577 @SelectServiceTypeClientTIXP
+  Scenario Outline: Selecting a Service Type Client TIXP
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And has selected the TI Service Type "<TI Service Type>" in DID configuration
+    Then the MILS configuration section is hidden
+    And the TIXP configuration section is displayed
+
+    Examples:
+      | username          | password  | TI Service Type |
+      | LLAdmin@looped.in | Octopus@6 | Client TIXP     |

--- a/test/pages/ODTI_UI/NewDIDConfiguration.js
+++ b/test/pages/ODTI_UI/NewDIDConfiguration.js
@@ -8,4 +8,24 @@ module.exports = {
     get existingDIDConfiguration() {
         return $('//div[contains(@id,"DIDConfigurationForm")]');
     },
+
+    get tiServiceTypeDropdown() {
+        return $('//select[contains(@id,"DIDConfiguration_TIServiceType")]')
+    },
+
+    get campusPinInputTextBox() {
+        return $('//input[contains(@id,"DIDConfiguration_CampusBillToId")]');
+    },
+
+    get campusNameBelowInputTextBox() {
+        return $('//span[contains(@id,"IsWithCampus")]/a');
+    },
+
+    get milsConfigurationSection() {
+        return $('//div[contains(text(),"MILS") and (contains(text(),"Configuration"))]/parent::div');
+    },
+
+    get tixpConfigurationSection() {
+        return $('//div[contains(text(),"TIXP") and (contains(text(),"Configuration"))]/parent::div');
+    },
 }

--- a/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
@@ -19,3 +19,33 @@ When(/^the DID is blank in existing DID configuration upon clicking duplicate$/,
     let didNumberOrigValue = action.getElementAttribute(newDIDConfigurationPage.didNumberInputTextBox,"origvalue");
     chai.expect(didNumberOrigValue).to.equal("");
 })
+
+When(/^has selected the TI Service Type "(.*)" in DID configuration$/, function (serviceType) {
+    action.isVisibleWait(newDIDConfigurationPage.tiServiceTypeDropdown);
+    action.selectTextFromDropdown(newDIDConfigurationPage.tiServiceTypeDropdown,serviceType);
+})
+
+When(/^has typed in a Campus PIN "(.*)" in DID configuration$/, function (campusPin) {
+    action.isVisibleWait(newDIDConfigurationPage.campusPinInputTextBox, 10000);
+    action.enterValue(newDIDConfigurationPage.campusPinInputTextBox,campusPin);
+})
+
+Then(/^the PIN is searched in DID configuration$/, function () {
+    let searchedCampusResultDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.campusNameBelowInputTextBox, 10000);
+    chai.expect(searchedCampusResultDisplayStatus).to.be.true;
+})
+
+Then(/^the Campus name "(.*)" is displayed below the input box in DID configuration$/, function (campusName) {
+    let campusNameTextBelowInputBox = action.getElementText(newDIDConfigurationPage.campusNameBelowInputTextBox);
+    chai.expect(campusNameTextBelowInputBox).to.equal(campusName);
+})
+
+Then(/^the MILS configuration section is hidden$/, function () {
+    let milsConfigurationSectionDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.milsConfigurationSection, 10000);
+    chai.expect(milsConfigurationSectionDisplayStatus).to.be.false;
+})
+
+Then(/^the TIXP configuration section is displayed$/, function () {
+    let tixpConfigurationSectionDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.tixpConfigurationSection, 10000);
+    chai.expect(tixpConfigurationSectionDisplayStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in New DID Configuration page.
- Added step methods to select TI Service type, enter campus pin, verify the campus name displayed below the input box, the MILS configuration section is hidden and the TIXP configuration section is displayed in DID configuration page.
- Automated scenarios 2 and 3a from LL-577 ticket