### PR TITLE
Automated scenarios 5 and 7a from LL-577 ticket

### DIFF
--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -104,3 +104,36 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  | TI Service Type |
       | LLAdmin@looped.in | Octopus@6 | General TI      |
+
+    #LL-577: Scenario 5 - Cancel
+  @LL-577 @DIDODTIConfigurationCancel
+  Scenario Outline: Cancel in DID Configuration
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And has selected the TI Service Type "<TI Service Type>" in DID configuration
+    And has typed in a Campus PIN "<campus pin>" in DID configuration
+    And the user has clicked the CANCEL button in DID configuration
+    Then the data entered is not saved in DID configuration
+    And the admin is navigated back to the configuration list screen
+
+    Examples:
+      | username          | password  | campus pin | TI Service Type |
+      | LLAdmin@looped.in | Octopus@6 | 29449      | NES Initiated   |
+
+    #LL-577: Scenario 7a - Adding business hours
+  @LL-577 @AddingBusinessHours
+  Scenario Outline: Adding business hours
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And the admin has clicked the Add More icon under the day-schedule
+    Then a schedule time modal window appears in DID configuration
+    And the modal contains drop-down boxes for the start time and end time, and Save & Cancel buttons
+    And the drop downs contain a list of times in 15minute increments from 00:00 to 23:59
+
+    Examples:
+      | username          | password  |
+      | LLAdmin@looped.in | Octopus@6 |

--- a/test/pages/ODTI_UI/NewDIDConfiguration.js
+++ b/test/pages/ODTI_UI/NewDIDConfiguration.js
@@ -28,4 +28,32 @@ module.exports = {
     get tixpConfigurationSection() {
         return $('//div[contains(text(),"TIXP") and (contains(text(),"Configuration"))]/parent::div');
     },
+
+    get cancelButton(){
+        return $('//input[@value="Cancel"]')
+    },
+
+    get addMoreButtonUnderSchedule() {
+        return $('//a[text()="Add More"]');
+    },
+
+    get scheduleTimePickerModal() {
+        return $('//div[contains(@aria-labelledby,"TimePickerModal")]');
+    },
+
+    get scheduleStartTimeDropdown() {
+        return $('//select[contains(@id,"ModalStartTimeInput")]');
+    },
+
+    get scheduleEndTimeDropdown() {
+        return $('//select[contains(@id,"ModalEndTimeInput")]');
+    },
+
+    get saveButtonOnScheduleTimePickerModal() {
+        return $('//input[contains(@id,"TimePickerModal") and @value="Save"]');
+    },
+
+    get cancelButtonOnScheduleTimePickerModal() {
+        return $('//input[contains(@id,"TimePickerModal") and @value="Cancel"]');
+    },
 }

--- a/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
@@ -66,3 +66,59 @@ Then(/^the MILS and TIXP configuration sections are not shown/, function () {
     let tixpConfigurationSectionDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.tixpConfigurationSection, 10000);
     chai.expect(tixpConfigurationSectionDisplayStatus).to.be.false;
 })
+
+When(/^the user has clicked the CANCEL button in DID configuration$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.cancelButton,10000);
+    action.clickElement(newDIDConfigurationPage.cancelButton);
+})
+
+Then(/^the data entered is not saved in DID configuration$/, function () {
+    let pageTitleActual = action.getPageTitle();
+    chai.expect(pageTitleActual).to.not.includes("New DID Configuration");
+})
+
+When(/^the admin has clicked the Add More icon under the day-schedule$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.addMoreButtonUnderSchedule,10000);
+    action.clickElement(newDIDConfigurationPage.addMoreButtonUnderSchedule);
+})
+
+Then(/^a schedule time modal window appears in DID configuration$/, function () {
+    let scheduleTimePickerModalWindowDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.scheduleTimePickerModal, 10000);
+    chai.expect(scheduleTimePickerModalWindowDisplayStatus).to.be.true;
+})
+
+Then(/^the modal contains drop-down boxes for the start time and end time, and Save & Cancel buttons$/, function () {
+    let startTimeDropdownDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.scheduleStartTimeDropdown, 10000);
+    chai.expect(startTimeDropdownDisplayStatus).to.be.true;
+    let endTimeDropdownDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.scheduleEndTimeDropdown, 10000);
+    chai.expect(endTimeDropdownDisplayStatus).to.be.true;
+    let saveButtonOnModalDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.saveButtonOnScheduleTimePickerModal, 10000);
+    chai.expect(saveButtonOnModalDisplayStatus).to.be.true;
+    let cancelButtonOnModalDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.cancelButtonOnScheduleTimePickerModal, 10000);
+    chai.expect(cancelButtonOnModalDisplayStatus).to.be.true;
+})
+
+Then(/^the drop downs contain a list of times in 15minute increments from 00:00 to 23:59$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.scheduleStartTimeDropdown, 10000);
+    let startTimeDropdownTimeValues = action.getElementText(newDIDConfigurationPage.scheduleStartTimeDropdown);
+    let endTimeDropdownTimeValues = action.getElementText(newDIDConfigurationPage.scheduleEndTimeDropdown);
+    let timeArray = [];
+    let startTime = "00:15:00";
+    let endTime = "23:59:00";
+    // Convert start and end time to Date objects
+    let startDate = new Date("2000-01-01 " + startTime);
+    let endDate = new Date("2000-01-01 " + endTime);
+    // Time difference
+    let delta = 15 * 60 * 1000; // 15 minutes in milliseconds
+    // Generate time values
+    let currentTime = startDate;
+    while (currentTime <= endDate) {
+        timeArray.push(currentTime.toTimeString().slice(0, 8));
+        currentTime = new Date(currentTime.getTime() + delta);
+    }
+    let numberOfTimeValues = timeArray.length;
+    for (let i = 0; i < numberOfTimeValues; i++) {
+        chai.expect(startTimeDropdownTimeValues).to.includes(timeArray[i]);
+        chai.expect(endTimeDropdownTimeValues).to.includes(timeArray[i]);
+    }
+})


### PR DESCRIPTION
- Added new locators in New DID Configuration page.
- Added step methods to click on CANCEL button, Add More icon under the day-schedule, to verify data entered is not saved, schedule time modal window displayed, modal contains drop-down boxes for the start time and end time, and Save & Cancel buttons and the drop downs contain a list of times in 15minute increments from 00:00 to 23:59 in DID configuration.
- Automated scenarios 5 and 7a from LL-577 ticket.