### PR TITLE
Automated scenarios 7b and 7c from LL-577 ticket

### DIFF
--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -137,3 +137,39 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  |
       | LLAdmin@looped.in | Octopus@6 |
+
+    #LL-577: Scenario 7b - Saving the business hours
+  @LL-577 @SavingBusinessHours
+  Scenario Outline: Saving the business hours
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And the admin has clicked the Add More icon under the day-schedule
+    And a schedule time modal window appears in DID configuration
+    And has selected start time "<start Time>" and end time "<end Time>" on the schedule-edit modal
+    And has clicked the SAVE button on schedule time modal
+    Then the schedule time modal window closes in DID configuration
+    And the selected start time "<start Time>" and end time "<end Time>" is reflected in the table for that day
+
+    Examples:
+      | username          | password  | start Time | end Time |
+      | LLAdmin@looped.in | Octopus@6 | 01:00:00   | 03:00:00 |
+
+    #LL-577: Scenario 7c - Cancelling the schedule-edit modal
+  @LL-577 @CancellingBusinessHours
+  Scenario Outline: Cancelling the schedule-edit modal
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And the admin has clicked the Add More icon under the day-schedule
+    And a schedule time modal window appears in DID configuration
+    And has selected start time "<start Time>" and end time "<end Time>" on the schedule-edit modal
+    And has clicked the CANCEL button on schedule time modal
+    Then the schedule time modal window closes in DID configuration
+    And the schedule for that day remains unchanged
+
+    Examples:
+      | username          | password  | start Time | end Time |
+      | LLAdmin@looped.in | Octopus@6 | 01:00:00   | 03:00:00 |

--- a/test/pages/ODTI_UI/NewDIDConfiguration.js
+++ b/test/pages/ODTI_UI/NewDIDConfiguration.js
@@ -56,4 +56,8 @@ module.exports = {
     get cancelButtonOnScheduleTimePickerModal() {
         return $('//input[contains(@id,"TimePickerModal") and @value="Cancel"]');
     },
+
+    get startEndTimeValueInScheduleTable() {
+        return $('//table[contains(@id,"DIDAdvScheduleTable")]/tbody/tr[1]/td[1]');
+    }
 }

--- a/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
@@ -122,3 +122,37 @@ Then(/^the drop downs contain a list of times in 15minute increments from 00:00 
         chai.expect(endTimeDropdownTimeValues).to.includes(timeArray[i]);
     }
 })
+
+When(/^has selected start time "(.*)" and end time "(.*)" on the schedule-edit modal$/, function (startTime,endTime) {
+    action.isVisibleWait(newDIDConfigurationPage.saveButtonOnScheduleTimePickerModal, 10000);
+    action.selectTextFromDropdown(newDIDConfigurationPage.scheduleStartTimeDropdown,startTime);
+    action.selectTextFromDropdown(newDIDConfigurationPage.scheduleEndTimeDropdown,endTime);
+})
+
+When(/^has clicked the SAVE button on schedule time modal$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.saveButtonOnScheduleTimePickerModal, 10000);
+    action.clickElement(newDIDConfigurationPage.saveButtonOnScheduleTimePickerModal);
+})
+
+Then(/^the schedule time modal window closes in DID configuration$/, function () {
+    let scheduleTimePickerModalWindowDisplayStatus = action.isNotVisibleWait(newDIDConfigurationPage.scheduleTimePickerModal, 2000);
+    chai.expect(scheduleTimePickerModalWindowDisplayStatus).to.be.false;
+})
+
+Then(/^the selected start time "(.*)" and end time "(.*)" is reflected in the table for that day$/, function (startTime,endTime) {
+    action.isVisibleWait(newDIDConfigurationPage.startEndTimeValueInScheduleTable,10000);
+    let startEndTimeValuesInTable = action.getElementText(newDIDConfigurationPage.startEndTimeValueInScheduleTable);
+    let startEndTimeExpected = startTime.slice(0,5) + " - " + endTime.slice(0,5);
+    chai.expect(startEndTimeValuesInTable).to.equal(startEndTimeExpected);
+})
+
+When(/^has clicked the CANCEL button on schedule time modal$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.cancelButtonOnScheduleTimePickerModal, 10000);
+    action.clickElement(newDIDConfigurationPage.cancelButtonOnScheduleTimePickerModal);
+})
+
+Then(/^the schedule for that day remains unchanged$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.startEndTimeValueInScheduleTable,10000);
+    let startEndTimeValuesInTable = action.getElementText(newDIDConfigurationPage.startEndTimeValueInScheduleTable);
+    chai.expect(startEndTimeValuesInTable).to.equal("No schedules set...");
+})


### PR DESCRIPTION
- Added new locators in New DID Configuration page.
- Added step methods to select start time, end time, click the SAVE button, click the CANCEL button, to verify the schedule time modal window closes, the selected start time and end time is reflected and the schedule remains unchanged in the table in DID configuration.
- Automated scenarios 7b and 7c from LL-577 ticket.