### PR TITLE
Automated scenarios 7d and 8a from LL-577 ticket

### DIFF
--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -173,3 +173,41 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  | start Time | end Time |
       | LLAdmin@looped.in | Octopus@6 | 01:00:00   | 03:00:00 |
+
+#LL-577: Scenario 7d - Removing business hours
+  @LL-577 @RemovingBusinessHours
+  Scenario Outline: Removing business hours
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And the admin has clicked the Add More icon under the day-schedule
+    And a schedule time modal window appears in DID configuration
+    And has selected start time "<start Time>" and end time "<end Time>" on the schedule-edit modal
+    And has clicked the SAVE button on schedule time modal
+    And the schedule time modal window closes in DID configuration
+    And the selected start time "<start Time>" and end time "<end Time>" is reflected in the table for that day
+    And there is an x icon displayed next to each Time Block row
+    And the admin clicks on the x icon in the schedule table
+    Then the Time Block is removed from the table
+    And a feedback message is displayed: Time block deleted
+
+    Examples:
+      | username          | password  | start Time | end Time |
+      | LLAdmin@looped.in | Octopus@6 | 01:00:00   | 03:00:00 |
+
+    #LL-577: Scenario 8a - Editing a language option
+  @LL-577 @EditingLanguageOption
+  Scenario Outline: Editing a language option
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And the admin has clicked the Edit icon beside a language option
+    And from out of nowhere, a modal window for Edit Language magically appears!
+    And the Edit Language modal contains a drop-down with a list of languages
+    And the Edit Language modal contains Save & Cancel buttons
+
+    Examples:
+      | username          | password  |
+      | LLAdmin@looped.in | Octopus@6 |

--- a/test/pages/ODTI_UI/NewDIDConfiguration.js
+++ b/test/pages/ODTI_UI/NewDIDConfiguration.js
@@ -59,5 +59,37 @@ module.exports = {
 
     get startEndTimeValueInScheduleTable() {
         return $('//table[contains(@id,"DIDAdvScheduleTable")]/tbody/tr[1]/td[1]');
-    }
+    },
+
+    get noSchedulesSetMessage() {
+        return $('//td[text()="No schedules set..."]');
+    },
+
+    get xIconInScheduleTable() {
+        return $('//table[contains(@id,"DIDAdvScheduleTable")]/tbody/tr[1]/td[4]//span');
+    },
+
+    get timeBlockDeletedFeedbackMessage() {
+        return $('//span[@class="Feedback_Message_Text" and text()="Time block deleted"]');
+    },
+
+    get editIconBesideLanguageOption() {
+        return $('//table[contains(@id,"TableLanguage")]/tbody/tr[1]/td[3]//span');
+    },
+
+    get editLanguageModalPopup() {
+        return $('//div[contains(@aria-labelledby,"LanguageModal")]');
+    },
+
+    get languageDropdownOnEditLanguageModal() {
+        return $('//select[contains(@id,"NewLanguageInput")]');
+    },
+
+    get saveButtonOnEditLanguageModal() {
+        return $('//input[contains(@name,"LanguageModal") and @value="Save"]');
+    },
+
+    get cancelButtonOnEditLanguageModal() {
+        return $('//input[contains(@name,"LanguageModal") and @value="Cancel"]');
+    },
 }

--- a/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
@@ -156,3 +156,45 @@ Then(/^the schedule for that day remains unchanged$/, function () {
     let startEndTimeValuesInTable = action.getElementText(newDIDConfigurationPage.startEndTimeValueInScheduleTable);
     chai.expect(startEndTimeValuesInTable).to.equal("No schedules set...");
 })
+
+When(/^there is an x icon displayed next to each Time Block row$/, function () {
+    let xIconInScheduleTableDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.xIconInScheduleTable, 10000);
+    chai.expect(xIconInScheduleTableDisplayStatus).to.be.true;
+})
+
+When(/^the admin clicks on the x icon in the schedule table$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.xIconInScheduleTable, 10000);
+    action.clickElement(newDIDConfigurationPage.xIconInScheduleTable);
+})
+
+Then(/^the Time Block is removed from the table$/, function () {
+    let noSchedulesSetMessageDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.noSchedulesSetMessage, 10000);
+    chai.expect(noSchedulesSetMessageDisplayStatus).to.be.true;
+})
+
+Then(/^a feedback message is displayed: Time block deleted$/, function () {
+    let timeBlockDeletedMessageDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.timeBlockDeletedFeedbackMessage, 10000);
+    chai.expect(timeBlockDeletedMessageDisplayStatus).to.be.true;
+})
+
+When(/^the admin has clicked the Edit icon beside a language option$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.editIconBesideLanguageOption, 10000);
+    action.clickElement(newDIDConfigurationPage.editIconBesideLanguageOption);
+})
+
+Then(/^from out of nowhere, a modal window for Edit Language magically appears!$/, function () {
+    let editLanguageModalDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.editLanguageModalPopup, 10000);
+    chai.expect(editLanguageModalDisplayStatus).to.be.true;
+})
+
+Then(/^the Edit Language modal contains a drop-down with a list of languages$/, function () {
+    let languageDropdownDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.languageDropdownOnEditLanguageModal, 10000);
+    chai.expect(languageDropdownDisplayStatus).to.be.true;
+})
+
+Then(/^the Edit Language modal contains Save & Cancel buttons$/, function () {
+    let saveButtonOnEditLanguageModalDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.saveButtonOnEditLanguageModal, 10000);
+    chai.expect(saveButtonOnEditLanguageModalDisplayStatus).to.be.true;
+    let cancelButtonOnEditLanguageModalDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.cancelButtonOnEditLanguageModal, 10000);
+    chai.expect(cancelButtonOnEditLanguageModalDisplayStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in New DID Configuration page.
- Added step methods to click on the x icon, Edit icon beside a language option, to verify x icon displayed next to each Time Block, Time Block is removed from the table, Time block deleted feedback message is displayed, modal window for Edit Language, drop-down with a list of languages, Save & Cancel buttons.
- Automated scenarios 7d and 8a from LL-577 ticket.