### PR TITLE
Automated scenarios 8b and 8c from LL-577 ticket

### DIFF
--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -211,3 +211,39 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  |
       | LLAdmin@looped.in | Octopus@6 |
+
+    #LL-577: Scenario 8b - Saving the Language option
+  @LL-577 @SavingLanguageOption
+  Scenario Outline: Saving the Language option
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And the admin has clicked the Edit icon beside a language option
+    And from out of nowhere, a modal window for Edit Language magically appears!
+    And has selected a language "<language Name>" form Language Name drop-down in Edit Language modal
+    And has clicked the SAVE button in Edit Language modal
+    Then the modal window for Edit Language closes
+    And the table now reflects the selected language "<language Name>" for the keypad option
+
+    Examples:
+      | username          | password  | language Name |
+      | LLAdmin@looped.in | Octopus@6 | ARABIC        |
+
+    #LL-577: Scenario 8c - Cancelling the modal
+  @LL-577 @CancellingLanguageOptionModal
+  Scenario Outline: Cancelling the Language option modal
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And the admin has clicked the Edit icon beside a language option
+    And from out of nowhere, a modal window for Edit Language magically appears!
+    And has selected a language "<language Name>" form Language Name drop-down in Edit Language modal
+    And has clicked the CANCEL button in Edit Language modal
+    Then the modal window for Edit Language closes
+    And the keypad option remains unchanged
+
+    Examples:
+      | username          | password  | language Name |
+      | LLAdmin@looped.in | Octopus@6 | ARABIC        |

--- a/test/pages/ODTI_UI/NewDIDConfiguration.js
+++ b/test/pages/ODTI_UI/NewDIDConfiguration.js
@@ -92,4 +92,8 @@ module.exports = {
     get cancelButtonOnEditLanguageModal() {
         return $('//input[contains(@name,"LanguageModal") and @value="Cancel"]');
     },
+
+    get languageSelectedTextInLanguageOptionsTable() {
+        return $('//table[contains(@id,"TableLanguage")]/tbody/tr[1]/td[2]/div');
+    },
 }

--- a/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
@@ -198,3 +198,35 @@ Then(/^the Edit Language modal contains Save & Cancel buttons$/, function () {
     let cancelButtonOnEditLanguageModalDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.cancelButtonOnEditLanguageModal, 10000);
     chai.expect(cancelButtonOnEditLanguageModalDisplayStatus).to.be.true;
 })
+
+When(/^has selected a language "(.*)" form Language Name drop-down in Edit Language modal$/, function (languageName) {
+    action.isVisibleWait(newDIDConfigurationPage.languageDropdownOnEditLanguageModal, 10000);
+    action.selectTextFromDropdown(newDIDConfigurationPage.languageDropdownOnEditLanguageModal, languageName);
+})
+
+When(/^has clicked the SAVE button in Edit Language modal$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.saveButtonOnEditLanguageModal, 10000);
+    action.clickElement(newDIDConfigurationPage.saveButtonOnEditLanguageModal);
+})
+
+Then(/^the modal window for Edit Language closes$/, function () {
+    let editLanguageModalDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.editLanguageModalPopup, 10000);
+    chai.expect(editLanguageModalDisplayStatus).to.be.true;
+})
+
+Then(/^the table now reflects the selected language "(.*)" for the keypad option$/, function (languageName) {
+    action.isVisibleWait(newDIDConfigurationPage.languageSelectedTextInLanguageOptionsTable, 10000);
+    let languageSelectedTextActual = action.getElementText(newDIDConfigurationPage.languageSelectedTextInLanguageOptionsTable, 10000);
+    chai.expect(languageSelectedTextActual).to.equal(languageName);
+})
+
+When(/^has clicked the CANCEL button in Edit Language modal$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.cancelButtonOnEditLanguageModal, 10000);
+    action.clickElement(newDIDConfigurationPage.cancelButtonOnEditLanguageModal);
+})
+
+Then(/^the keypad option remains unchanged$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.languageSelectedTextInLanguageOptionsTable, 10000);
+    let languageSelectedTextActual = action.getElementText(newDIDConfigurationPage.languageSelectedTextInLanguageOptionsTable, 10000);
+    chai.expect(languageSelectedTextActual).to.equal("");
+})


### PR DESCRIPTION
- Added new locators in New DID Configuration page.
- Added step methods to select a language, click on SAVE button, CANCEL button in Edit Language modal, to verify the modal window for Edit Language closes, the table reflects the selected language for the keypad option and the keypad option remains unchanged.
- Automated scenarios 8b and 8c from LL-577 ticket.