### PR TITLE
Automated scenarios 9 and 10 from LL-577 ticket

### DIFF
--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -247,3 +247,41 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  | language Name |
       | LLAdmin@looped.in | Octopus@6 | ARABIC        |
+
+    #LL-577: Scenario 9: Entering the same DID number that already exists
+  @LL-577 @EnteringDIDNumberAlreadyExists
+  Scenario Outline: Cancel in DID Configuration
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And has selected the TI Service Type "<TI Service Type>" in DID configuration
+    And has typed in a Campus PIN "<campus pin>" in DID configuration
+    And the user enters the same DID number "<DID number>" that already exists
+    And the user has filled in all the required data "<welcome Audio File Name>", "<closed Audio File Name>", "<language Audio File>", "<timezone>" in New DID Configuration
+    And has clicked the SAVE button in New DID Configuration page
+    Then the error text message Duplicate phone number exists! is displayed
+
+    Examples:
+      | username          | password  | campus pin | TI Service Type | DID number    | welcome Audio File Name | closed Audio File Name | language Audio File | timezone             |
+      | LLAdmin@looped.in | Octopus@6 | 29449      | Client TIXP     | 6173 0821 466 | test1.wmv               | test2.wmv              | test3.wmv           | (UTC+10:00) Brisbane |
+
+    #LL-577: Scenario 10: Adding the time blocks that exists between the existing time blocks
+  @LL-577 @AddingTimeBlocksBetweenExisting
+  Scenario Outline: Adding the time blocks that exists between the existing time blocks
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the Admin is on the Edit DID Configuration screen of Campus "<campus>"
+    And the user is navigated to the Edit DID Configuration screen
+    And the admin has clicked the Add More icon under the day-schedule
+    And a schedule time modal window appears in DID configuration
+    And has selected start time "<start Time>" and end time "<end Time>" on the schedule-edit modal
+    And has clicked the SAVE button on schedule time modal
+    And the user enters the same time block with weekdays "<weekdays>" that comes in the same time block and same days which already exists
+    And has clicked the SAVE button on schedule time modal
+    Then the error text message Time block overlaps with another time block is displayed
+
+    Examples:
+      | username          | password  | campus                  | start Time | end Time | weekdays |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD | 01:00:00   | 03:00:00 | Sat,Sun  |

--- a/test/pages/ODTI_UI/NewDIDConfiguration.js
+++ b/test/pages/ODTI_UI/NewDIDConfiguration.js
@@ -96,4 +96,36 @@ module.exports = {
     get languageSelectedTextInLanguageOptionsTable() {
         return $('//table[contains(@id,"TableLanguage")]/tbody/tr[1]/td[2]/div');
     },
+
+    get welcomeAudioFileNameTextBox() {
+        return $('//input[contains(@id,"DIDConfiguration_WelcomeAudioFilename")]');
+    },
+
+    get closedAudioFileNameTextBox() {
+        return $('//input[contains(@id,"DIDConfiguration_CloseAudioFilename")]');
+    },
+
+    get languageAudioFileNameTextBox() {
+        return $('//input[contains(@id,"DIDConfiguration_LanguageAudioFilename")]');
+    },
+
+    get timezoneDropdown() {
+        return $('//select[contains(@id,"Timezone")]');
+    },
+
+    get saveButtonOnNewDIDConfiguration() {
+        return $('//input[@value="Save" and (contains(@id,"Actions")) and not(contains(@id,"Modal"))]');
+    },
+
+    get duplicatePhoneNumberExistsErrorMessage() {
+        return $('//span[@class="ValidationMessage" and text()="Duplicate phone number exists!"]');
+    },
+
+    get weekdaysCheckboxOnTimePickerModalDynamicLocator() {
+        return '//input[@type="checkbox" and (contains(@id,"<dynamic>"))]';
+    },
+
+    get blockOverlapsErrorFeedbackMessage() {
+        return $('//span[@class="Feedback_Message_Text" and text()="Time block overlaps with another time block"]');
+    }
 }

--- a/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
@@ -230,3 +230,40 @@ Then(/^the keypad option remains unchanged$/, function () {
     let languageSelectedTextActual = action.getElementText(newDIDConfigurationPage.languageSelectedTextInLanguageOptionsTable, 10000);
     chai.expect(languageSelectedTextActual).to.equal("");
 })
+
+When(/^the user enters the same DID number "(.*)" that already exists$/, function (DIDNumber) {
+    action.isVisibleWait(newDIDConfigurationPage.didNumberInputTextBox, 10000);
+    action.enterValue(newDIDConfigurationPage.didNumberInputTextBox, DIDNumber);
+})
+
+When(/^the user has filled in all the required data "(.*)", "(.*)", "(.*)", "(.*)" in New DID Configuration$/, function (welcomeAudioFileName, closedAudioFileName, languageAudioFile, timezone) {
+    action.isVisibleWait(newDIDConfigurationPage.welcomeAudioFileNameTextBox, 10000);
+    action.enterValue(newDIDConfigurationPage.welcomeAudioFileNameTextBox, welcomeAudioFileName);
+    action.enterValue(newDIDConfigurationPage.closedAudioFileNameTextBox, closedAudioFileName);
+    action.enterValue(newDIDConfigurationPage.languageAudioFileNameTextBox, languageAudioFile);
+    action.selectTextFromDropdown(newDIDConfigurationPage.timezoneDropdown, timezone);
+})
+
+When(/^has clicked the SAVE button in New DID Configuration page$/, function () {
+    action.isVisibleWait(newDIDConfigurationPage.saveButtonOnNewDIDConfiguration, 10000);
+    action.clickElement(newDIDConfigurationPage.saveButtonOnNewDIDConfiguration);
+})
+
+Then(/^the error text message Duplicate phone number exists! is displayed$/, function () {
+    let duplicateNumberErrorMessageDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.duplicatePhoneNumberExistsErrorMessage, 10000);
+    chai.expect(duplicateNumberErrorMessageDisplayStatus).to.be.true;
+})
+
+When(/^the user enters the same time block with weekdays "(.*)" that comes in the same time block and same days which already exists$/, function (weekdays) {
+    let weekdaysList = weekdays.split(",");
+    for (let i = 0; i < weekdaysList.length; weekdaysList++) {
+        let weekdayCheckbox = $(newDIDConfigurationPage.weekdaysCheckboxOnTimePickerModalDynamicLocator.replace("<dynamic>", weekdaysList[i]));
+        action.isVisibleWait(weekdayCheckbox, 10000);
+        action.clickElement(weekdayCheckbox);
+    }
+})
+
+Then(/^the error text message Time block overlaps with another time block is displayed$/, function () {
+    let blockOverlapsErrorFeedbackMessageDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.blockOverlapsErrorFeedbackMessage, 10000);
+    chai.expect(blockOverlapsErrorFeedbackMessageDisplayStatus).to.be.true;
+})


### PR DESCRIPTION
- Added new locators in New DID Configuration page.
- Added step methods to enter DID number, fill in all the required data, click the SAVE button, to select weekdays checkboxes on time block, to verify the error text message Duplicate phone number exists and error text message Time block overlaps with another time block is displayed.
- Automated scenarios 9 and 10 from LL-577 ticket