### PR TITLE
Automated scenarios 1 and 2 in LL-635 ticket

### DIFF
--- a/test/features/InterpretingBookingManagement/BookingsAllocations.feature
+++ b/test/features/InterpretingBookingManagement/BookingsAllocations.feature
@@ -120,3 +120,35 @@ Feature: Bookings Allocations Features
     Examples:
       | username cbo   | password cbo | contractorID |
       | zenq@cbo11.com | Test1        | 6155         |
+
+    #LL-635 Scenario 1: Campus PIN in URL (internal)
+  @LL-635 @CampusPINInURLBookingRequest
+  Scenario Outline: Campus PIN in URL (internal) Booking Request
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And an internal user has accessed the Booking Request screen from URL
+    And the Booking Request URL contains the CampusPIN parameter "<campusPIN>"
+    Then the Job Request screen will display
+    And the CampusPIN "<campusPIN>" should be prefilled in the input box
+    And RequesterMode should be set to Phone
+    And the rest of the form should display as if the user has typed a Campus PIN and pressed enter "<job requester details>"
+
+    Examples:
+      | username        | password  | campusPIN | job requester details |
+      | zenq2@ll.com.au | Reset@312 | 29449     | 29449,Contoso Pty LTD |
+
+    #LL-635 Scenario 2: Invalid Campus PIN in URL (internal)
+  @LL-635 @InvalidCampusPINInURLBookingRequest
+  Scenario Outline: Invalid Campus PIN in URL (internal)
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And an internal user has accessed the Booking Request screen from URL
+    And the Booking Request URL contains the CampusPIN parameter "<invalid campusPIN>"
+    Then the Job Request screen will display
+    And the CampusPIN "<invalid campusPIN>" should be prefilled in the input box
+    And the error message No Campus PIN found is displayed
+    And the rest of the form should display as if the user has typed a Campus PIN and pressed enter "<job requester details>"
+
+    Examples:
+      | username        | password  | invalid campusPIN | job requester details |
+      | zenq2@ll.com.au | Reset@312 | 2944909           | 2944909               |

--- a/test/pages/Booking/JobRequestPage.js
+++ b/test/pages/Booking/JobRequestPage.js
@@ -404,4 +404,16 @@ module.exports={
     get cfOnSiteTextBox(){
         return $('//*[text()="CF_OnSite"]/../../..//input[contains(@id,"txtInputStd")]')
     },
+
+    get requesterModePhoneActive() {
+        return $('//label[contains(@class,"active") and text()="Phone"]');
+    },
+
+    get jobRequesterDetailsForm() {
+        return $('//div[text()="Job Requester Details"]/parent::div');
+    },
+
+    get noCampusPinFoundMessage() {
+        return $('//span[@class="Feedback_Message_Text" and text()="No Campus PIN found"]');
+    }
 }

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -700,3 +700,32 @@ When(/^I enter CF_OnSite "(.*)"$/, function(CF_OnSite){
   action.isVisibleWait(jobRequestPage.cfOnSiteTextBox,10000)
   action.enterValue(jobRequestPage.cfOnSiteTextBox,CF_OnSite)
 })
+
+Then(/^the Job Request screen will display$/, function () {
+  let pageTitleActual = action.getPageTitle();
+  chai.expect(pageTitleActual).to.includes("Booking Request");
+})
+
+Then(/^the CampusPIN "(.*)" should be prefilled in the input box$/, function (campusPin) {
+  action.isVisibleWait(jobRequestPage.campusPinInput, 20000);
+  let campusPinPrefilledValueActual = action.getElementValue(jobRequestPage.campusPinInput);
+  chai.expect(campusPinPrefilledValueActual).to.equal(campusPin);
+})
+
+Then(/^RequesterMode should be set to Phone$/, function () {
+  let requesterModePhoneActiveDisplayStatus = action.isVisibleWait(jobRequestPage.requesterModePhoneActive, 20000);
+  chai.expect(requesterModePhoneActiveDisplayStatus).to.be.true;
+})
+
+Then(/^the rest of the form should display as if the user has typed a Campus PIN and pressed enter "(.*)"$/, function (jobRequesterDetails) {
+  let jobRequesterDetailsList = jobRequesterDetails.split(",");
+  let jobRequesterDetailsPageHtml = action.getElementHTML(jobRequestPage.jobRequesterDetailsForm);
+  for (let i = 0; i < jobRequesterDetailsList.length; i++) {
+    chai.expect(jobRequesterDetailsPageHtml).to.includes(jobRequesterDetailsList[i]);
+  }
+})
+
+Then(/^the error message No Campus PIN found is displayed$/, function () {
+  let noCampusPinFoundMessageDisplayStatus = action.isVisibleWait(jobRequestPage.noCampusPinFoundMessage, 20000);
+  chai.expect(noCampusPinFoundMessageDisplayStatus).to.be.true;
+})

--- a/test/stepdefinition/Interpreting/InterpretingSteps.js
+++ b/test/stepdefinition/Interpreting/InterpretingSteps.js
@@ -255,3 +255,11 @@ Then(/^a Contractor ID filter should not be displayed and pre filled with the gi
     chai.expect(contractorIDValuePreFilledDisplayStatus).to.be.false;
   }
 })
+
+When(/^an internal user has accessed the Booking Request screen from URL$/, function () {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/BookingRequest.aspx");
+})
+
+When(/^the Booking Request URL contains the CampusPIN parameter "(.*)"$/, function (campusPin) {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/BookingRequest.aspx?CampusPIN=" + campusPin);
+})


### PR DESCRIPTION
- Added new locators in Job request page.
- Added step methods to access the Booking Request screen from URL with CampusPIN parameter, to verify the Job Request screen is displayed, the CampusPIN is prefilled in the input box, RequesterMode is set to Phone, rest of the form is displayed and the error message No Campus PIN found is displayed.
- Automated scenarios 1 and 2 in LL-635 ticket.