### PR TITLE
Automated scenarios 3 and 4 in LL-635 ticket

### DIFF
--- a/test/features/InterpretingBookingManagement/BookingsAllocations.feature
+++ b/test/features/InterpretingBookingManagement/BookingsAllocations.feature
@@ -152,3 +152,34 @@ Feature: Bookings Allocations Features
     Examples:
       | username        | password  | invalid campusPIN | job requester details |
       | zenq2@ll.com.au | Reset@312 | 2944909           | 2944909               |
+
+    #LL-635 Scenario 3: Inactive Campus PIN in URL (internal)
+  @LL-635 @InactiveCampusPINInURLBookingRequest
+  Scenario Outline: Inactive Campus PIN in URL (internal)
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And an internal user has accessed the Booking Request screen from URL
+    And the Booking Request URL contains the CampusPIN parameter "<inactive campusPIN>"
+    Then the Job Request screen will display
+    And the CampusPIN "<inactive campusPIN>" should be prefilled in the input box
+    And the error message The Campus is Inactive is displayed
+    And the rest of the form should display as if the user has typed a Campus PIN and pressed enter "<job requester details>"
+
+    Examples:
+      | username        | password  | inactive campusPIN | job requester details |
+      | zenq2@ll.com.au | Reset@312 | 28063              | 28063                 |
+
+    #LL-635 Scenario 4: Campus PIN in URL (CBO User with multiple campuses)
+  @LL-635 @CampusPINInURLCBOMultiple
+  Scenario Outline: Campus PIN in URL (CBO User with multiple campuses)
+    When I login with "<username cbo>" and "<password cbo>"
+    And I click Interpreting header link
+    And an CBO user has accessed the Booking Request screen from URL
+    And user enters Campus PIN "<campusPIN option>" in the URL
+    Then the Job Request screen will display
+    And the CampusPIN "<campusPIN option>" should not be prefilled in the input box for CBO
+    And the page still stays as if no campus is selected for CBO
+
+    Examples:
+      | username cbo   | password cbo | campusPIN option |
+      | zenq@cbo11.com | Test1        | 29449            |

--- a/test/pages/Booking/JobRequestPage.js
+++ b/test/pages/Booking/JobRequestPage.js
@@ -415,5 +415,17 @@ module.exports={
 
     get noCampusPinFoundMessage() {
         return $('//span[@class="Feedback_Message_Text" and text()="No Campus PIN found"]');
+    },
+
+    get campusInactiveMessage() {
+        return $('//span[@class="Feedback_Message_Text" and text()="The Campus is Inactive"]');
+    },
+
+    get campusPinDropDownOption() {
+        return '//select[contains(@id,"PINSingle")]/option[contains(text(),"<dynamic>")]';
+    },
+
+    get locationAddressValueField() {
+        return $('//input[contains(@id,"wtInput_wttxtAddress") and @value]');
     }
 }

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -729,3 +729,19 @@ Then(/^the error message No Campus PIN found is displayed$/, function () {
   let noCampusPinFoundMessageDisplayStatus = action.isVisibleWait(jobRequestPage.noCampusPinFoundMessage, 20000);
   chai.expect(noCampusPinFoundMessageDisplayStatus).to.be.true;
 })
+
+Then(/^the error message The Campus is Inactive is displayed$/, function () {
+  let campusInactiveMessageDisplayStatus = action.isVisibleWait(jobRequestPage.campusInactiveMessage, 20000);
+  chai.expect(campusInactiveMessageDisplayStatus).to.be.true;
+})
+
+Then(/^the CampusPIN "(.*)" should not be prefilled in the input box for CBO$/, function (campusPin) {
+  let campusPinDropdownOption = $(jobRequestPage.campusPinDropDownOption.replace("<dynamic>",campusPin));
+  let campusPinDropdownOptionSelectedStatus = action.isSelectedWait(campusPinDropdownOption, 1000);
+  chai.expect(campusPinDropdownOptionSelectedStatus).to.be.false;
+})
+
+Then(/^the page still stays as if no campus is selected for CBO$/, function () {
+  let selectedCampusLocationValueExistStatus = action.isExistingWait(jobRequestPage.locationAddressValueField, 1000);
+  chai.expect(selectedCampusLocationValueExistStatus).to.be.false;
+})

--- a/test/stepdefinition/Interpreting/InterpretingSteps.js
+++ b/test/stepdefinition/Interpreting/InterpretingSteps.js
@@ -263,3 +263,11 @@ When(/^an internal user has accessed the Booking Request screen from URL$/, func
 When(/^the Booking Request URL contains the CampusPIN parameter "(.*)"$/, function (campusPin) {
   action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/BookingRequest.aspx?CampusPIN=" + campusPin);
 })
+
+When(/^an CBO user has accessed the Booking Request screen from URL$/, function () {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/ClientBookingRequest.aspx");
+})
+
+When(/^user enters Campus PIN "(.*)" in the URL$/, function (campusPin) {
+  action.launchURL("https://li-uat.languageloop.com.au/LoopedIn/ClientBookingRequest.aspx?CampusPIN=" + campusPin);
+})


### PR DESCRIPTION
- Added new locators in Job request page.
- Added step methods to access the Booking Request screen from URL with Campus pin parameter as CBO, to verify the Job Request screen is displayed, error message The Campus is Inactive is displayed, Campus pin not prefilled in the input box for CBO and the page stays as if no campus is selected for CBO.
- Automated scenarios 3 and 4 in LL-635 ticket - In progress.