### PR TITLE
Automated scenario 5 in LL-635 and 1a in LL-646 ticket

### DIFF
--- a/test/features/InterpretingBookingManagement/BookingsAllocations.feature
+++ b/test/features/InterpretingBookingManagement/BookingsAllocations.feature
@@ -183,3 +183,17 @@ Feature: Bookings Allocations Features
     Examples:
       | username cbo   | password cbo | campusPIN option |
       | zenq@cbo11.com | Test1        | 29449            |
+
+    #LL-635 Scenario 5: Campus PIN in URL (CBO User with single campus)
+  @LL-635 @CampusPINInURLCBOSingle
+  Scenario Outline: Campus PIN in URL (CBO User with single campus)
+    When I login with "<username cbo>" and "<password cbo>"
+    And I click Interpreting header link
+    And an CBO user has accessed the Booking Request screen from URL
+    And user enters Campus PIN "<campusPIN option>" in the URL
+    Then the Job Request screen will display
+    And the CampusPIN "<campusPIN option>" is prefilled in the input box as it has only 1 campus pin for CBO
+
+    Examples:
+      | username cbo   | password cbo | campusPIN option |
+      | zenq@cbo10.com | Test1        | 29449            |

--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -430,3 +430,18 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  | start Time | end Time | weekdays |
       | LLAdmin@looped.in | Octopus@6 | 01:00:00   | 04:00:00 | Sun,Mon  |
+
+    #LL-646: Scenario 1a: There should be a Delete icon beside the Pencil icon
+  @LL-646 @DeleteIconBesidePencilIcon
+  Scenario Outline: There should be a Delete icon beside the Pencil icon
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the Admin is on the Edit DID Configuration screen of Campus "<campus>"
+    And the user is navigated to the Edit DID Configuration screen
+    Then there should be an X icon on each of the language options that has a language set
+    And options with no Language set do not have an X icon
+
+    Examples:
+      | username          | password  | campus                  |
+      | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |

--- a/test/pages/ODTI_UI/EditDIDConfiguration.js
+++ b/test/pages/ODTI_UI/EditDIDConfiguration.js
@@ -4,4 +4,16 @@ module.exports = {
     get existingConfiguration() {
         return $('//div[contains(@id,"DIDConfigurationForm")]');
     },
+
+    get xIconBesideLanguageOptionDynamicLocator() {
+        return '//table[contains(@id,"TableLanguage")]/tbody/tr[<dynamic>]/td[4]//span';
+    },
+
+    get languageTextDynamicLocator() {
+        return '//table[contains(@id,"TableLanguage")]/tbody/tr[<dynamic>]/td[2]/div';
+    },
+
+    get languageTableBodyRowsCount() {
+        return $$('//table[contains(@id,"TableLanguage")]/tbody/tr').length;
+    },
 }

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -745,3 +745,9 @@ Then(/^the page still stays as if no campus is selected for CBO$/, function () {
   let selectedCampusLocationValueExistStatus = action.isExistingWait(jobRequestPage.locationAddressValueField, 1000);
   chai.expect(selectedCampusLocationValueExistStatus).to.be.false;
 })
+
+Then(/^the CampusPIN "(.*)" is prefilled in the input box as it has only 1 campus pin for CBO$/, function (campusPin) {
+  let campusPinDropdownOption = $(jobRequestPage.campusPinDropDownOption.replace("<dynamic>",campusPin));
+  let campusPinDropdownOptionSelectedStatus = action.isSelectedWait(campusPinDropdownOption, 1000);
+  chai.expect(campusPinDropdownOptionSelectedStatus).to.be.true;
+})

--- a/test/stepdefinition/ODTI_UI/EditDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/EditDIDConfigurationSteps.js
@@ -7,3 +7,30 @@ Then(/^the existing configuration is shown$/, function () {
     let existingConfigurationDisplayStatus = action.isVisibleWait(editDIDConfigurationPage.existingConfiguration, 10000);
     chai.expect(existingConfigurationDisplayStatus).to.be.true;
 })
+
+
+Then(/^there should be an X icon on each of the language options that has a language set$/, function () {
+    let rowsCount = editDIDConfigurationPage.languageTableBodyRowsCount;
+    for (let row = 1; row <= rowsCount; row++) {
+        let languageTextElement = $(editDIDConfigurationPage.languageTextDynamicLocator.replace("<dynamic>", row.toString()));
+        let languageTextElementValue = action.getElementText(languageTextElement);
+        let xIconBesideLanguage = $(editDIDConfigurationPage.xIconBesideLanguageOptionDynamicLocator.replace("<dynamic>", row.toString()));
+        if (languageTextElementValue !== "") {
+            let xIconBesideLanguageDisplayStatus = action.isVisibleWait(xIconBesideLanguage, 10000);
+            chai.expect(xIconBesideLanguageDisplayStatus).to.be.true;
+        }
+    }
+})
+
+Then(/^options with no Language set do not have an X icon$/, function () {
+    let rowsCount = editDIDConfigurationPage.languageTableBodyRowsCount;
+    for (let row = 1; row <= rowsCount; row++) {
+        let languageTextElement = $(editDIDConfigurationPage.languageTextDynamicLocator.replace("<dynamic>", row.toString()));
+        let languageTextElementValue = action.getElementText(languageTextElement);
+        let xIconBesideLanguage = $(editDIDConfigurationPage.xIconBesideLanguageOptionDynamicLocator.replace("<dynamic>", row.toString()));
+        if (languageTextElementValue === "") {
+            let xIconBesideLanguageDisplayStatus = action.isVisibleWait(xIconBesideLanguage, 10000);
+            chai.expect(xIconBesideLanguageDisplayStatus).to.be.false;
+        }
+    }
+})


### PR DESCRIPTION
- Added new locators in Edit DID configuration page.
- Added step methods to verify campus pin is prefilled in the input box when there is only 1 campus pin for CBO in Job request, X icon is displayed on each of the language options that has a language set and X icon is not displayed for options with no Language in DID configuration.
- Automated scenario 5 in LL-635 ticket - Completed.
- Started and automated scenario 1a in LL-646 ticket.