### PR TITLE
Automated scenario 4a and 4b in LL-655 ticket

### DIFF
--- a/test/features/ODTI_UI/DIDConfiguration.feature
+++ b/test/features/ODTI_UI/DIDConfiguration.feature
@@ -461,3 +461,34 @@ Feature: ODTI_UI DID Configuration features
     Examples:
       | username          | password  | campus                  |
       | LLAdmin@looped.in | Octopus@6 | 29449 - Contoso Pty LTD |
+
+    #LL-655: Scenario 4a: UI for the DID Configuration
+  @LL-655 @DIDAllFourOptionsEnabled
+  Scenario Outline: UI for the DID Configuration - all four options should be enabled
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the user has clicked on the New Configuration button under DID Configuration tab
+    And has selected the TI Service Type "<TI Service Type>" in DID configuration
+    Then the Default Configuration Panel should display
+    And all four options "<configuration toggles>" should be enabled in Default Configuration
+
+    Examples:
+      | username          | password  | TI Service Type | configuration toggles                                                                                      |
+      | LLAdmin@looped.in | Octopus@6 | General TI      | Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number |
+
+    #LL-655: Scenario 4b: UI for the DID Configuration
+  @LL-655 @FourOptionsShouldDisplaySavedValues
+  Scenario Outline: UI for the DID Configuration - the four options should display the saved values
+    When I login with "<username>" and "<password>"
+    And the ODTI DID Configurations page is opened
+    And the Admin is on the DID Configurations Tab
+    And the Admin clicks on Edit for an existing DID Configuration with General TI
+    And the user is navigated to the Edit DID Configuration screen
+    And the selected ServiceType in Edit DID configuration is "<TI Service Type>"
+    Then the Default Configuration Panel should display
+    And the four options "<configuration toggles>" should display the saved values
+
+    Examples:
+      | username          | password  | TI Service Type | configuration toggles                                                                                      |
+      | LLAdmin@looped.in | Octopus@6 | General TI      | Accept Calls on Public Holidays,Prompt Gender Preference,Prompt if More than 30 Mins,Prompt for NES Number |

--- a/test/pages/ODTI_UI/DIDConfigurations.js
+++ b/test/pages/ODTI_UI/DIDConfigurations.js
@@ -112,4 +112,12 @@ module.exports = {
     get campusNameLinksDIDConfigurationLocator() {
         return '//a[text()="<dynamicCampusPin>"]';
     },
+
+    get editGeneralTiDIDConfigurationLinksLocator() {
+        return '//td[contains(text(),"General TI")]/parent::tr/td/a[text()="Edit"]';
+    },
+
+    get editGeneralTiDIDConfigurationLinkLocator() {
+        return '(//td[contains(text(),"General TI")]/parent::tr/td/a[text()="Edit"])[<dynamicIndex>]';
+    },
 }

--- a/test/pages/ODTI_UI/EditDIDConfiguration.js
+++ b/test/pages/ODTI_UI/EditDIDConfiguration.js
@@ -24,4 +24,12 @@ module.exports = {
     get languageTextAssignedToNumericOptionDynamicLocator() {
         return '//table[contains(@id,"TableLanguage")]/tbody/tr//div[text()="<dynamic>"]/parent::td/following-sibling::td[1]/div'; //dynamic option number
     },
+
+    get tiServiceTypeDropdownOptionDynamicLocator() {
+        return '//select[contains(@id,"DIDConfiguration_TIServiceType")]/option[text()="<dynamic>"]'; //dynamic TI Service Type
+    },
+
+    get configurationToggleCheckboxLocator() {
+        return '//label[text()="<dynamic>"]/parent::div//input';
+    },
 }

--- a/test/pages/ODTI_UI/NewDIDConfiguration.js
+++ b/test/pages/ODTI_UI/NewDIDConfiguration.js
@@ -155,5 +155,13 @@ module.exports = {
 
     get startEndTimeDynamicLocator() {
         return '//table[contains(@id,"DIDAdvScheduleTable")]/tbody/tr[<dynamic>]/td[1]';
-    }
+    },
+
+    get defaultConfigurationSection() {
+        return $('//div[contains(text(),"Default") and (contains(text(),"Configuration"))]/parent::div');
+    },
+
+    get configurationToggleCheckboxLocator() {
+        return '//label[text()="<dynamic>"]/parent::div//input';
+    },
 }

--- a/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
+++ b/test/stepdefinition/ODTI_UI/DIDConfigurationsSteps.js
@@ -181,3 +181,16 @@ When(/^the Admin has clicked on the Campus Name "(.*)" in the DID configuration 
         }
     }
 })
+
+When(/^the Admin clicks on Edit for an existing DID Configuration with General TI$/, function () {
+    let editDIDConfigurationLinksCount = $$(DIDConfigurationsPage.editGeneralTiDIDConfigurationLinksLocator).length;
+    for (let index = 1; index <= editDIDConfigurationLinksCount; index++) {
+        let editDIDConfigurationLink = $(DIDConfigurationsPage.editGeneralTiDIDConfigurationLinkLocator.replace("<dynamicIndex>", index.toString()));
+        action.isNotVisibleWait(editDIDConfigurationLink, 2000,"Edit DID configuration link in DID configuration page");
+        let editLinkVisible = action.isVisibleWait(editDIDConfigurationLink, 1000,"Edit DID configuration link in DID configuration page");
+        if (editLinkVisible) {
+            action.clickElement(editDIDConfigurationLink,"Edit DID configuration link in DID configuration page");
+            break;
+        }
+    }
+})

--- a/test/stepdefinition/ODTI_UI/EditDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/EditDIDConfigurationSteps.js
@@ -52,3 +52,19 @@ Then(/^the X icon disappears in Language Options table$/, function () {
     let xIconBesideLanguageDisplayStatus = action.isVisibleWait(xIconBesideLanguage, 1000);
     chai.expect(xIconBesideLanguageDisplayStatus).to.be.false;
 })
+
+Then(/^the selected ServiceType in Edit DID configuration is "(.*)"$/, function (tiServiceTypeOption) {
+    let tiServiceTypeDropdownOption = $(editDIDConfigurationPage.tiServiceTypeDropdownOptionDynamicLocator.replace("<dynamic>", tiServiceTypeOption));
+    let tiServiceTypeDropdownOptionSelectedStatus = action.isSelectedWait(tiServiceTypeDropdownOption, 10000,"TI Service Type Dropdown Option in Edit DID Configuration page");
+    chai.expect(tiServiceTypeDropdownOptionSelectedStatus).to.be.true;
+})
+
+Then(/^the four options "(.*)" should display the saved values$/, function (configurationToggles) {
+    let configurationTogglesList = configurationToggles.split(",")
+    for (let index = 0; index < configurationTogglesList.length; index++) {
+        let configurationToggleElement = $(editDIDConfigurationPage.configurationToggleCheckboxLocator.replace("<dynamic>", configurationTogglesList[index]));
+        let toggleOriginalValue = action.getElementAttribute(configurationToggleElement, "origvalue", "Toggle option " + configurationTogglesList[index] + " in Edit DID Configuration page");
+        let toggleHasSavedValues = toggleOriginalValue === "true" || toggleOriginalValue === "false";
+        chai.expect(toggleHasSavedValues).to.be.true;
+    }
+})

--- a/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
+++ b/test/stepdefinition/ODTI_UI/NewDIDConfigurationSteps.js
@@ -371,3 +371,17 @@ Then(/^that time block "(.*)","(.*)" is deleted$/, function (startTime,endTime) 
     let didScheduleTableTextAfterDelete = action.getElementText(newDIDConfigurationPage.scheduleTableBody);
     chai.expect(didScheduleTableTextAfterDelete).to.not.includes(startEndTimeExpected);
 })
+
+Then(/^the Default Configuration Panel should display$/, function () {
+    let defaultConfigurationSectionDisplayStatus = action.isVisibleWait(newDIDConfigurationPage.defaultConfigurationSection, 10000, "Default Configuration Panel in New DID Configuration page");
+    chai.expect(defaultConfigurationSectionDisplayStatus).to.be.true;
+})
+
+Then(/^all four options "(.*)" should be enabled in Default Configuration$/, function (configurationToggles) {
+    let configurationTogglesList = configurationToggles.split(",")
+    for (let index = 0; index < configurationTogglesList.length; index++) {
+        let configurationToggleElement = $(newDIDConfigurationPage.configurationToggleCheckboxLocator.replace("<dynamic>", configurationTogglesList[index]));
+        let toggleOriginalValue = action.getElementAttribute(configurationToggleElement, "origvalue", "Toggle option " + configurationTogglesList[index] + " in New DID Configuration page");
+        chai.expect(toggleOriginalValue).to.equal("true");
+    }
+})

--- a/test/utils/actions.js
+++ b/test/utils/actions.js
@@ -194,7 +194,7 @@ module.exports={
             }
         }
         if (eltFriendlyName !== undefined) {
-            logger.info(eltFriendlyName + " is clickable status after waiting is "+isClickable);
+            logger.info(eltFriendlyName + " is clickable status = "+isClickable);
         }
         return isClickable;
     },
@@ -212,7 +212,7 @@ module.exports={
             }
         }
         if (eltFriendlyName !== undefined) {
-            logger.info(eltFriendlyName + " is Visible status after waiting is "+isVisible);
+            logger.info(eltFriendlyName + " is Visible status = "+isVisible);
         }
         return isVisible;
     },
@@ -245,7 +245,7 @@ module.exports={
             }
         }
         if (eltFriendlyName !== undefined) {
-            logger.info(eltFriendlyName + " is Existing status after waiting is "+isExisting);
+            logger.info(eltFriendlyName + " is Existing status = "+isExisting);
         }
         return isExisting;
     },
@@ -263,7 +263,7 @@ module.exports={
             }
         }
         if (eltFriendlyName !== undefined) {
-            logger.info(eltFriendlyName + " is Selected status after waiting is "+isSelected);
+            logger.info(eltFriendlyName + " is Selected status = "+isSelected);
         }
         return isSelected;
     },
@@ -290,7 +290,7 @@ module.exports={
     pressKeys(keys){
         browser.keys(keys)
         if (keys !== undefined) {
-            logger.info("Pressed keyboard keys " + keys);
+            logger.info("Pressed keyboard key - " + keys);
         }
     },
 
@@ -380,7 +380,7 @@ module.exports={
             }
         }
         if (eltFriendlyName !== undefined) {
-            logger.info(eltFriendlyName + " is visible status after waiting is "+isVisible);
+            logger.info(eltFriendlyName + " is visible status = "+isVisible);
         }
         return isVisible;
     },
@@ -416,7 +416,7 @@ module.exports={
             }
         }
         if (eltFriendlyName !== undefined) {
-            logger.info(eltFriendlyName + " is enabled status after waiting is "+isEnabled);
+            logger.info(eltFriendlyName + " is enabled status = "+isEnabled);
         }
         return isEnabled;
     },
@@ -430,7 +430,7 @@ module.exports={
     getElementAttribute(elt,attributeName, eltFriendlyName){
         let elementAttributeValue = elt.getAttribute(attributeName)
         if (eltFriendlyName !== undefined) {
-            logger.info("Fetched Attribute " + attributeName + "  value of " + eltFriendlyName + " as " + elementAttributeValue);
+            logger.info("Fetched Attribute " + attributeName + " value of " + eltFriendlyName + " as " + elementAttributeValue);
         }
         return elementAttributeValue;
     },


### PR DESCRIPTION
- Added new locators in DID configuration, New DID configuration and Edit DID configuration pages.
- Added step methods to click on Edit for an existing DID Configuration, to verify the selected ServiceType in Edit DID configuration is General TI, the Default Configuration Panel is displayed, all four options should be enabled in Default Configuration and display the saved values.
- Automated scenario 4a and 4b in LL-655 ticket.
- Updated log statements for few methods in utilities action methods.