### PR TITLE
Enabled failed spec for re-execution

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -96,7 +96,8 @@ exports.config = {
     // directory is where your package.json resides, so `wdio` will be called from there.
     //
     specs: [
-        './test/features/**/*.feature'
+        // './test/features/**/*.feature'
+        './test/features/InterpretingBookingManagement/InterpreterStatus.feature'
         // './test/features/**/Claims.feature'
     ],
     // Patterns to exclude.


### PR DESCRIPTION
- Enabled failed spec InterpreterStatus.feature for re-execution.