### PR TITLE
Automated scenarios 1b and 1c in LL-676 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsFinance.feature
+++ b/test/features/ODTI/ODTIJobsFinance.feature
@@ -112,3 +112,39 @@ Feature: ODTI Jobs Finance features
     Examples:
       | username              | password |
       | testauto@finance1.com | Test1    |
+
+    #LL-676 Scenario 1b: New campus pin is for a different contract
+  @LL-676 @NewCampusPinDifferentContract
+  Scenario Outline: New campus pin is for a different contract
+    When I login with "<username>" and "<password>"
+    And I click ODTI header link
+    And I view the ODTI > ODTI Jobs page
+    And they will see a table
+    And they click the ODTI Service Charge ID hyperlink
+    And they are navigated to the Job Details page in a new tab
+    And I want to change the campus pin by clicking on the Edit icon
+    And I select the new campus pin "<new campus pin>" which is for a different contract
+    Then a pop up message will appear before I can proceed The new campus pin is for a different contract, are you sure you want to proceed
+
+    Examples:
+      | username              | password | new campus pin |
+      | testauto@finance1.com | Test1    | 33124          |
+
+    #LL-676 Scenario 1c: The rate schedule is available for both campus contracts e.g. PH rate, BH hours
+  @LL-676 @RateScheduleAvailableCampusContracts
+  Scenario Outline: The rate schedule is available for both campus contracts e.g. PH rate, BH hours
+    When I login with "<username>" and "<password>"
+    And I click ODTI header link
+    And I view the ODTI > ODTI Jobs page
+    And they will see a table
+    And they click the ODTI Service Charge ID hyperlink
+    And they are navigated to the Job Details page in a new tab
+    And I want to change the campus pin by clicking on the Edit icon
+    And I select the new campus pin "<new campus pin>" which is for a different contract
+    And I click OK on alert popups after selecting the a new campus pin
+    And I click on Migrate & Recalculate Job Fee after selecting a new campus pin
+    Then an following error message will appear The Job PIN could not be migrated No contract rate found for Contract ID: XX’ and will not allow the user to proceed with that PIN
+
+    Examples:
+      | username              | password | new campus pin |
+      | testauto@finance1.com | Test1    | 32548          |

--- a/test/pages/ODTI/ODTIJobDetails.js
+++ b/test/pages/ODTI/ODTIJobDetails.js
@@ -11,5 +11,21 @@ module.exports = {
 
     get newPinMustBeSelectedAndValidErrorMessage() {
         return $('//div[text()="New PIN must be selected and valid"]');
+    },
+
+    get selectPinLink() {
+        return $('//a[text()="Select PIN"]');
+    },
+
+    get pinTextBoxUnderFilterBy() {
+        return $('input[placeholder="PIN"]')
+    },
+
+    get pinSearchResultLinkDynamicLocator() {
+        return '//a[contains(@id,"ChangeJobPINModal") and text()="<dynamic>"]';
+    },
+
+    get noContractRateFoundErrorMessage() {
+        return $('//div[text()="The Job PIN could not be migrated. No contract rate found for Contract ID:1136 and will not allow the user to proceed with that PIN."]');
     }
 }

--- a/test/stepdefinition/ODTI/ODTIJobDetails.js
+++ b/test/stepdefinition/ODTI/ODTIJobDetails.js
@@ -12,3 +12,49 @@ Then(/^an inline message in red will appear New PIN must be selected and valid$/
     let newPinMustBeSelectedAndValidErrorMessageDisplayStatus = action.isVisibleWait(ODTIJobDetailsPage.newPinMustBeSelectedAndValidErrorMessage, 10000,"New PIN must be selected and valid Error message in ODTI job details page");
     chai.expect(newPinMustBeSelectedAndValidErrorMessageDisplayStatus).to.be.true;
 })
+
+When(/^I select the new campus pin "(.*)" which is for a different contract$/, function (campusPin) {
+    action.isVisibleWait(ODTIJobDetailsPage.selectPinLink, 10000, "Select Pin link in ODTI job details page");
+    action.clickElement(ODTIJobDetailsPage.selectPinLink, "Select Pin link in ODTI job details page");
+    action.isVisibleWait(ODTIJobDetailsPage.pinTextBoxUnderFilterBy, 10000, "PIN text box under filter by in ODTI job details page");
+    action.enterValue(ODTIJobDetailsPage.pinTextBoxUnderFilterBy, campusPin, "PIN text box under filter by in ODTI job details page");
+    let pinSearchResultLink = $(ODTIJobDetailsPage.pinSearchResultLinkDynamicLocator.replace("<dynamic>",campusPin));
+    action.isVisibleWait(pinSearchResultLink, 10000, "Pin search result link in ODTI job details page");
+    action.clickElement(pinSearchResultLink, "Pin search result link in ODTI job details page");
+})
+
+Then(/^a pop up message will appear before I can proceed The new campus pin is for a different contract, are you sure you want to proceed$/, function () {
+    let newPinProceedAlertPopupMessage = action.getAlertText();
+    chai.expect(newPinProceedAlertPopupMessage).to.equal("The new campus pin is for a different contract, are you sure you want to proceed?")
+})
+
+When(/^I click OK on alert popups after selecting the a new campus pin$/, function () {
+    browser.waitUntil(function () {
+        return (action.isAlertOpenWait(5000)) === true
+    }, {
+        timeout: 5000,
+        timeoutMsg: 'expected alert to be displayed within 5s',
+        interval: 500
+    })
+    action.getAlertText();
+    action.acceptAlert();
+    browser.waitUntil(function () {
+        return (action.isAlertOpenWait(5000)) === true
+    }, {
+        timeout: 5000,
+        timeoutMsg: 'expected alert to be displayed within 5s',
+        interval: 500
+    })
+    action.getAlertText();
+    action.acceptAlert();
+})
+
+When(/^I click on Migrate & Recalculate Job Fee after selecting a new campus pin$/, function () {
+    action.isVisibleWait(ODTIJobDetailsPage.migrateAndRecalculateJobFeeButton, 10000,"Migrate And Recalculate Job Fee Button in ODTI job details page");
+    action.clickElement(ODTIJobDetailsPage.migrateAndRecalculateJobFeeButton, "Migrate And Recalculate Job Fee Button in ODTI job details page");
+})
+
+Then(/^an following error message will appear The Job PIN could not be migrated No contract rate found for Contract ID: XX’ and will not allow the user to proceed with that PIN$/, function () {
+    let noContractRateFoundErrorMessageDisplayStatus = action.isVisibleWait(ODTIJobDetailsPage.noContractRateFoundErrorMessage, 10000,"The Job PIN could not be migrated. No contract rate found for Contract ID:xx and will not allow the user to proceed with that PIN. Error message in ODTI job details page");
+    chai.expect(noContractRateFoundErrorMessageDisplayStatus).to.be.true;
+})

--- a/test/utils/actions.js
+++ b/test/utils/actions.js
@@ -525,5 +525,21 @@ module.exports={
         browser.reloadSession()
         logger.info("Reloaded Session");
     },
+
+    isAlertOpenWait(waitTime) {
+        let isAlertOpen = false;
+        let i = 0;
+        while (i <= waitTime) {
+            isAlertOpen = browser.isAlertOpen();
+            if (isAlertOpen) {
+                break;
+            } else {
+                browser.pause(500);
+                i = i + 500;
+            }
+        }
+        logger.info("Alert open status = " + isAlertOpen);
+        return isAlertOpen;
+    },
 }
 

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -103,6 +103,7 @@ exports.config = {
     // Patterns to exclude.
     exclude: [
         // 'path/to/excluded/files'
+        './test/features/InterpretingBookingManagement/InterpreterStatus.feature',
     ],
     //
     // ============


### PR DESCRIPTION
- Excluded Interpreter status scenarios from execution.
- Added step methods to select the new campus pin, to verify a pop up message new campus pin is for a different contract is displayed, to click OK on alert popups, to click on Migrate & Recalculate Job Fee button and to verify error message No contract rate found for Contract ID is displayed.
- Automated scenarios 1b and 1c in LL-676 ticket.
- Added new action method to wait until the alert is open.