### PR TITLE
Automated scenarios 2 and 5 in LL-224 ticket

### DIFF
--- a/test/features/ContractorPortal/ContractorManagement.feature
+++ b/test/features/ContractorPortal/ContractorManagement.feature
@@ -362,3 +362,37 @@ Feature: Contractor Management features
   Examples:
    | username          | password  | contractor name |
    | LLAdmin@looped.in | Octopus@6 | Aabida SUNASARA |
+
+  #LL-224 Scenario 2: View or check current status from web contractor portal (deactivated)
+ @LL-224 @InternalUserCheckODTIStatusDeactivated
+ Scenario Outline: View or check current status from web contractor portal (deactivated)
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  And the Activate toggle is off for ODTI
+  Then the section is closed and text Not Activated is displayed
+  And the contractor’s current login status is NOT displayed
+
+  Examples:
+   | username          | password  | contractor name |
+   | LLAdmin@looped.in | Octopus@6 | Aabida SUNASARA |
+
+  #LL-224 Scenario 5: Verify the Work Availability for ODTI for contractor when ODTI Availability is De Activated
+ @LL-225 @WorkAvailabilityODTIDeactivated
+ Scenario Outline: Verify the Work Availability for ODTI for contractor when ODTI Availability is De Activated
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  And the Activate toggle is off for ODTI
+  And I click logout button
+  And I login with "<contractor username>" and "<contractor password>"
+  And I click "<contractor name>" user link
+  And the contractor is viewing their profile
+  And I click on Work Availability for ODTI
+  Then the text ‘You are not activated for On Demand Telephone Interpreting’ is displayed
+
+  Examples:
+   | username          | password  | contractor username  | contractor password | contractor name |
+   | LLAdmin@looped.in | Octopus@6 | w.f_2006@yahoo.co.uk | Test1               | Aabida SUNASARA |

--- a/test/features/ContractorPortal/ContractorManagement.feature
+++ b/test/features/ContractorPortal/ContractorManagement.feature
@@ -323,3 +323,42 @@ Feature: Contractor Management features
   Examples:
    | username          | password  | contractor name |
    | LLAdmin@looped.in | Octopus@6 | Aabida SUNASARA |
+
+  #LL-763 Scenario 4: Toggling ON the ‘SERVICE TI ACTIVE’ status for a interpreter
+ @LL-763 @ToggleOnServiceTiActive
+ Scenario Outline: Toggling ON the ‘SERVICE TI ACTIVE’ status for a interpreter
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  And the Activate toggle is off for ODTI
+  And the section is closed and text Not Activated is displayed
+  And user is on Admin Tools
+  And I click ODTI Contractors header link
+  And the Show Logged in Contractors Only toggle is off
+  And user search for the contractor "<contractor name>" and toggle on SERVICE TI ACTIVE
+  And I click LoopedIn header logo
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  Then the contractor’s log out status text is displayed with options Mobile and Home radio options with corresponding phone numbers
+  And the button Logon button is displayed
+
+  Examples:
+   | username          | password  | contractor name |
+   | LLAdmin@looped.in | Octopus@6 | Aabida SUNASARA |
+
+  #LL-224 Scenario 1: View or check current status from web contractor portal
+ @LL-224 @InternalUserCheckODTILoginStatus
+ Scenario Outline: UI when Active button is toggled on and no option is selected
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  And the Activate toggle is off for ODTI
+  And the contractor is Activated for ODTI
+  Then the contractor’s log out status text is displayed with options Mobile and Home radio options with corresponding phone numbers
+
+  Examples:
+   | username          | password  | contractor name |
+   | LLAdmin@looped.in | Octopus@6 | Aabida SUNASARA |

--- a/test/pages/MyProfile/MyProfile.js
+++ b/test/pages/MyProfile/MyProfile.js
@@ -262,6 +262,17 @@ module.exports ={
 
     get contractorLoggedInWithDefaultPhoneSelected() {
         return $('//div[text()="Contractor available and current contact number is:"]/following-sibling::div[contains(text(),"Home:")]');
-    }
+    },
 
+    get workAvailabilityListOptionDynamicLocator() {
+        return '//div[text()="Work Availability"]/parent::div/div[2]//div[text()="<dynamic>"]';
+    },
+
+    get workAvailabilityListOptionExpandedLinks() {
+        return $$('//a[contains(@id,"ContractorAvailabilityTable")]');
+    },
+
+    get workAvailabilityNotActivatedODTIText() {
+        return $('//div[text()="You are not activated for On Demand Telephone Interpreting"]');
+    }
 }

--- a/test/stepdefinition/AdminTools/ODTIContractorsSteps.js
+++ b/test/stepdefinition/AdminTools/ODTIContractorsSteps.js
@@ -71,3 +71,20 @@ Then(/^user search for the contractor "(.*)" and toggle off SERVICE TI ACTIVE$/,
         })
     }
 })
+
+Then(/^user search for the contractor "(.*)" and toggle on SERVICE TI ACTIVE$/, function (contractor) {
+    action.isVisibleWait(ODTIContractorsPage.searchByIdAndNameTextBox, 10000, "Search by Id and Name text box in ODTI Contractors page");
+    action.enterValue(ODTIContractorsPage.searchByIdAndNameTextBox, contractor, "Search by Id and Name text box in ODTI Contractors page");
+    action.clickElement(ODTIContractorsPage.searchButton, "Search button in ODTI Contractors page");
+    action.waitUntilLoadingIconDisappears();
+    let serviceTiActiveToggleInput = $(ODTIContractorsPage.serviceTiActiveToggleInput.replace("<dynamic>", contractor));
+    let serviceTiActiveToggleLabel = $(ODTIContractorsPage.serviceTiActiveToggleLabel.replace("<dynamic>", contractor));
+    let serviceTiActiveActivatedStatus = action.isSelectedWait(serviceTiActiveToggleInput, 3000, "SERVICE TI ACTIVE contractors toggle input in ODTI Contractors page");
+    if (serviceTiActiveActivatedStatus === false) {
+        action.clickElement(serviceTiActiveToggleLabel, "SERVICE TI ACTIVE contractors toggle label in ODTI Contractors page");
+        browser.waitUntil(() => action.isSelectedWait(serviceTiActiveToggleInput, 0, "SERVICE TI ACTIVE contractors toggle input in ODTI Contractors page") === true, {
+            timeout: 5000,
+            timeoutMsg: 'SERVICE TI ACTIVE toggle not enabled in 5s',
+        })
+    }
+})

--- a/test/stepdefinition/MyProfile/MyProfileSteps.js
+++ b/test/stepdefinition/MyProfile/MyProfileSteps.js
@@ -281,3 +281,26 @@ Then(/^the user is logged in with default phone number selected under ‘On-dema
     let contractorLoggedInWithDefaultPhoneSelectedDisplayStatus = action.isVisibleWait(myProfilePage.contractorLoggedInWithDefaultPhoneSelected, 20000, "Contractor logged in with default phone number selected under Text in My profile page");
     chai.expect(contractorLoggedInWithDefaultPhoneSelectedDisplayStatus).to.be.true;
 })
+
+Then(/^the contractor’s current login status is NOT displayed$/, function () {
+    let contractorLoginStatusDisplayStatus = action.isVisibleWait(myProfilePage.contractorLoginStatusAndPreferredPhone, 0, "Contractor login status and preferred phone block in My profile page");
+    chai.expect(contractorLoginStatusDisplayStatus).to.be.false;
+})
+
+Then(/^I click on Work Availability for ODTI$/, function () {
+    let workAvailabilityListOnDemandTelephoneOption = $(myProfilePage.workAvailabilityListOptionDynamicLocator.replace("<dynamic>", "On Demand Telephone"));
+    action.isVisibleWait(workAvailabilityListOnDemandTelephoneOption, 10000, "Work availability option - On Demand Telephone in My profile page");
+    action.clickElement(workAvailabilityListOnDemandTelephoneOption, "Work availability option - On Demand Telephone in My profile page");
+    let workAvailabilityListOptionExpandedLinks = myProfilePage.workAvailabilityListOptionExpandedLinks;
+    for (let linkIndex = 0; linkIndex < workAvailabilityListOptionExpandedLinks.length; linkIndex++) {
+        if (action.isClickableWait(workAvailabilityListOptionExpandedLinks[linkIndex], 100, "Work Availability List Option Expanded Link " + linkIndex + " in My profile page") === true) {
+            action.clickElement(workAvailabilityListOptionExpandedLinks[linkIndex], "Work Availability List Option Expanded Link " + linkIndex + " in My profile page");
+            break;
+        }
+    }
+})
+
+Then(/^the text ‘You are not activated for On Demand Telephone Interpreting’ is displayed$/, function () {
+    let notActivatedODTITextDisplayStatus = action.isVisibleWait(myProfilePage.workAvailabilityNotActivatedODTIText, 0, "You are not activated for On Demand Telephone Interpreting text under work availability in My profile page");
+    chai.expect(notActivatedODTITextDisplayStatus).to.be.false;
+})


### PR DESCRIPTION
- Added locators in My profile page.
- Added step methods to verify the the contractor’s current login status is not displayed, to click on the Work Availability for ODTI and to verify the text ‘You are not activated for On Demand Telephone Interpreting’ is displayed.
- Automated scenarios 2 and 5 in LL-224 ticket under Release 22.09-1.