### PR TITLE
Automated S6 in LL-224 and S1 in LL-730

### DIFF
--- a/test/features/ContractorPortal/ContractorManagement.feature
+++ b/test/features/ContractorPortal/ContractorManagement.feature
@@ -379,7 +379,7 @@ Feature: Contractor Management features
    | LLAdmin@looped.in | Octopus@6 | Aabida SUNASARA |
 
   #LL-224 Scenario 5: Verify the Work Availability for ODTI for contractor when ODTI Availability is De Activated
- @LL-225 @WorkAvailabilityODTIDeactivated
+ @LL-224 @WorkAvailabilityODTIDeactivated
  Scenario Outline: Verify the Work Availability for ODTI for contractor when ODTI Availability is De Activated
   When I login with "<username>" and "<password>"
   And I click contractor engagement link
@@ -392,6 +392,26 @@ Feature: Contractor Management features
   And the contractor is viewing their profile
   And I click on Work Availability for ODTI
   Then the text ‘You are not activated for On Demand Telephone Interpreting’ is displayed
+
+  Examples:
+   | username          | password  | contractor username  | contractor password | contractor name |
+   | LLAdmin@looped.in | Octopus@6 | w.f_2006@yahoo.co.uk | Test1               | Aabida SUNASARA |
+
+  #LL-224 Scenario 6: Verify the Work Availability for ODTI for contractor when ODTI Availability is Activated
+ @LL-224 @WorkAvailabilityODTIActivated
+ Scenario Outline: Verify the Work Availability for ODTI for contractor when ODTI Availability is Activated
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  And the Activate toggle is off for ODTI
+  And the contractor is Activated for ODTI
+  And I click logout button
+  And I login with "<contractor username>" and "<contractor password>"
+  And I click "<contractor name>" user link
+  And the contractor is viewing their profile
+  And I click on Work Availability for ODTI
+  Then the text ‘You are activated for On Demand Telephone Interpreting’ is displayed
 
   Examples:
    | username          | password  | contractor username  | contractor password | contractor name |

--- a/test/features/InterpretingBookingManagement/Bookings.feature
+++ b/test/features/InterpretingBookingManagement/Bookings.feature
@@ -1013,3 +1013,22 @@ Feature: Create new booking for Interpreters
     Examples:
       | username       | password | campusPin               | language | time  | new time |
       | zenq@cbo11.com | Test1    | 29449 - Contoso Pty LTD | zz-Zenq2 | 00:45 | 01:00    |
+
+    #LL-730 Scenario 1: Find Contractor popup appears
+  @LL-730 @FindContractorPopup
+  Scenario Outline: Find Contractor popup appears
+    When I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And I click on new job request button
+    And I select campus pin "<campusPin>" from Campus PIN dropdown
+    And I select language "<language>"
+    And I enter long notice schedule date
+    And they have selected a Time "<time>" from the time picker
+    And I select assignment type "<assignment type>"
+    And I click add preferred interpreter button
+    Then the Find Contractor popup appears
+    And the names of the available contractors are still hidden
+
+    Examples:
+      | username          | password | campusPin                       | language | time  | assignment type |
+      | atester@ll.com.au | Test1    | 33124 - BOLTON CLARKE - DH RDNS | ARABIC   | 10:00 | DH05-HalfDay    |

--- a/test/pages/Booking/JobRequestPage.js
+++ b/test/pages/Booking/JobRequestPage.js
@@ -443,5 +443,13 @@ module.exports={
 
     get customFieldDynamicLabel() {
         return '//div[contains(@id,"CustFields")]//span[text()="<dynamic>"]';
+    },
+
+    get findContractorPopup() {
+        return $('//span[text()="Find Contractor"]/parent::div/parent::div[contains(@id,"DialogContainer")]');
+    },
+
+    get findContractorTableNameHeader() {
+        return $('//table[contains(@id,"ContractorTable")]//th[text()="Name"]');
     }
 }

--- a/test/pages/MyProfile/MyProfile.js
+++ b/test/pages/MyProfile/MyProfile.js
@@ -274,5 +274,9 @@ module.exports ={
 
     get workAvailabilityNotActivatedODTIText() {
         return $('//div[text()="You are not activated for On Demand Telephone Interpreting"]');
+    },
+
+    get workAvailabilityActivatedODTIText() {
+        return $('//div[text()="You are activated for On Demand Telephone Interpreting"]');
     }
 }

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -788,3 +788,13 @@ When(/^the custom field for which the option is Audible in ODTI is unselected is
   let audibleInOdtiCustomFieldDisplayStatus = action.isVisibleWait(customFieldLabel, 1000,"Audible in ODTI custom field "+GlobalData.CUSTOMISED_FIELD_NAME+" in Job Request Page");
   chai.expect(audibleInOdtiCustomFieldDisplayStatus).to.be.true;
 })
+
+Then(/^the Find Contractor popup appears$/, function () {
+  let findContractorPopupDisplayStatus = action.isVisibleWait(jobRequestPage.findContractorPopup,10000,"Find Contractor Popup in Job Request Page");
+  chai.expect(findContractorPopupDisplayStatus).to.be.true;
+})
+
+Then(/^the names of the available contractors are still hidden$/, function () {
+  let findContractorTableNameHeaderDisplayStatus = action.isVisibleWait(jobRequestPage.findContractorTableNameHeader,0,"Find Contractor Table Name header in Job Request Page");
+  chai.expect(findContractorTableNameHeaderDisplayStatus).to.be.false;
+})

--- a/test/stepdefinition/MyProfile/MyProfileSteps.js
+++ b/test/stepdefinition/MyProfile/MyProfileSteps.js
@@ -304,3 +304,8 @@ Then(/^the text ‘You are not activated for On Demand Telephone Interpreting’
     let notActivatedODTITextDisplayStatus = action.isVisibleWait(myProfilePage.workAvailabilityNotActivatedODTIText, 0, "You are not activated for On Demand Telephone Interpreting text under work availability in My profile page");
     chai.expect(notActivatedODTITextDisplayStatus).to.be.false;
 })
+
+Then(/^the text ‘You are activated for On Demand Telephone Interpreting’ is displayed$/, function () {
+    let activatedODTITextDisplayStatus = action.isVisibleWait(myProfilePage.workAvailabilityActivatedODTIText, 0, "You are activated for On Demand Telephone Interpreting text under work availability in My profile page");
+    chai.expect(activatedODTITextDisplayStatus).to.be.false;
+})

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -99,8 +99,7 @@ exports.config = {
     // directory is where your package.json resides, so `wdio` will be called from there.
     //
     specs: [
-        // './test/features/**/*.feature'
-        './test/features/InterpretingBookingManagement/CancelBookings.feature'
+        './test/features/**/*.feature'
         // './test/features/**/Claims.feature'
     ],
     // Patterns to exclude.


### PR DESCRIPTION
- Added locators in my profile page and job request page.
- Added step methods to verify the text ‘You are activated for On Demand Telephone Interpreting’ is displayed, to verify the Find Contractor popup appears and the names of the available contractors are hidden.
- Automated scenario 6 in LL-224 ticket under Release 22.09-1.
- Automated scenario 1 in LL-730 ticket under Release 22.09-1.