### PR TITLE
Automated scenarios 1a, 1b and 1c in LL-768 ticket

### DIFF
--- a/test/features/ContractorPortal/ContractorManagement.feature
+++ b/test/features/ContractorPortal/ContractorManagement.feature
@@ -416,3 +416,48 @@ Feature: Contractor Management features
   Examples:
    | username          | password  | contractor username  | contractor password | contractor name |
    | LLAdmin@looped.in | Octopus@6 | w.f_2006@yahoo.co.uk | Test1               | Aabida SUNASARA |
+
+  #LL-768 Scenario 1a: Activation toggle switch (as admin / contractor engagement officer)
+ @LL-768 @ActivationToggleSwitchAdminCEO
+ Scenario Outline: Activation toggle switch (as admin / contractor engagement officer)
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  Then a toggle switch should be displayed on the top-right corner of the On-demand Telephone Interpreting Availability section
+
+  Examples:
+   | username        | password  | contractor name |
+   | zenq1@ll.com.au | Reset@312 | Aabida SUNASARA |
+
+  #LL-768 Scenario 1b: Activation toggle switch (logged in as contractor)
+ @LL-768 @ActivationToggleSwitchContractor
+ Scenario Outline: Activation toggle switch (logged in as contractor)
+  And I login with "<contractor username>" and "<contractor password>"
+  And I click "<contractor name>" user link
+  And the contractor is viewing their profile
+  Then a toggle switch should NOT be displayed on the top-right corner of the On-demand Telephone Interpreting Availability section
+
+  Examples:
+   | contractor username  | contractor password | contractor name |
+   | w.f_2006@yahoo.co.uk | Test1               | Aabida SUNASARA |
+
+  #LL-768 Scenario 1c: Activation toggle switch-OFF (as admin / contractor engagement officer)
+ @LL-768 @ActivationToggleOffAdminCEO
+ Scenario Outline: Activation toggle switch-OFF (as admin / contractor engagement officer)
+  When I login with "<username>" and "<password>"
+  And I click contractor engagement link
+  And I search and select contractor "<contractor name>"
+  And they will be navigated to the Contractor’s profile
+  And the Activate toggle is off for ODTI
+  And the section is closed and text Not Activated is displayed
+  And user is on Admin Tools
+  And I click ODTI Contractors header link
+  And the Show Logged in Contractors Only toggle is off
+  And user search for the contractor "<contractor name>" in admin tools
+  Then state of the Contractors "<contractor name>" ODTI Activation ServiceTIActive flag is set to False
+  And the Contractors "<contractor name>" ODTI Logged On State is set to False
+
+  Examples:
+   | username        | password  | contractor name |
+   | zenq1@ll.com.au | Reset@312 | Aabida SUNASARA |

--- a/test/stepdefinition/AdminTools/ODTIContractorsSteps.js
+++ b/test/stepdefinition/AdminTools/ODTIContractorsSteps.js
@@ -88,3 +88,22 @@ Then(/^user search for the contractor "(.*)" and toggle on SERVICE TI ACTIVE$/, 
         })
     }
 })
+
+When(/^user search for the contractor "(.*)" in admin tools$/, function (contractor) {
+    action.isVisibleWait(ODTIContractorsPage.searchByIdAndNameTextBox, 10000, "Search by Id and Name text box in ODTI Contractors page");
+    action.enterValue(ODTIContractorsPage.searchByIdAndNameTextBox, contractor, "Search by Id and Name text box in ODTI Contractors page");
+    action.clickElement(ODTIContractorsPage.searchButton, "Search button in ODTI Contractors page");
+    action.waitUntilLoadingIconDisappears();
+})
+
+Then(/^state of the Contractors "(.*)" ODTI Activation ServiceTIActive flag is set to False$/, function (contractor) {
+    let serviceTiActiveToggleInput = $(ODTIContractorsPage.serviceTiActiveToggleInput.replace("<dynamic>", contractor));
+    let serviceTiActiveActivatedStatus = action.isSelectedWait(serviceTiActiveToggleInput, 0, "SERVICE TI ACTIVE contractors toggle input in ODTI Contractors page");
+    chai.expect(serviceTiActiveActivatedStatus).to.be.false;
+})
+
+Then(/^the Contractors "(.*)" ODTI Logged On State is set to False$/, function (contractor) {
+    let isLoggedOnToggleInput = $(ODTIContractorsPage.isLoggedOnToggleInput.replace("<dynamic>", contractor));
+    let isLoggedOnActivatedStatus = action.isSelectedWait(isLoggedOnToggleInput, 0, "Is logged on contractors toggle input in ODTI Contractors page");
+    chai.expect(isLoggedOnActivatedStatus).to.be.false;
+})

--- a/test/stepdefinition/ContractorEngagement/ContractorEngagementSteps.js
+++ b/test/stepdefinition/ContractorEngagement/ContractorEngagementSteps.js
@@ -876,3 +876,13 @@ Then(/^the Activate toggle is off for ODTI$/, function () {
         })
     }
 })
+
+Then(/^a toggle switch should be displayed on the top-right corner of the On-demand Telephone Interpreting Availability section$/, function () {
+    let contractorActivateToggleSwitchDisplayStatus = action.isVisibleWait(contractorEngagementPage.ODTIAvailabilityActivateToggleLabel,10000,"ODTI Availability Activate toggle in Contractor Engagement page");
+    chai.expect(contractorActivateToggleSwitchDisplayStatus).to.be.true;
+})
+
+Then(/^a toggle switch should NOT be displayed on the top-right corner of the On-demand Telephone Interpreting Availability section$/, function () {
+    let contractorActivateToggleSwitchDisplayStatus = action.isVisibleWait(contractorEngagementPage.ODTIAvailabilityActivateToggleLabel,10000,"ODTI Availability Activate toggle in Contractor Engagement page");
+    chai.expect(contractorActivateToggleSwitchDisplayStatus).to.be.false;
+})


### PR DESCRIPTION
- Added step methods to verify a toggle switch on the top-right corner of the ODTI Availability section is displayed or not displayed, to search for the contractor, to verify the state of the Contractors ODTI Activation ServiceTIActive flag is set to False, to verify the Contractors ODTI Logged On State is set to False.
- Automated scenarios 1a, 1b and 1c in LL-768 ticket under Release 22.09-1.