### PR TITLE
Automated S3 in LL-897 and S1 in LL-899 ticket

### DIFF
--- a/test/features/InterpretingBookingManagement/CampusBookings.feature
+++ b/test/features/InterpretingBookingManagement/CampusBookings.feature
@@ -351,3 +351,16 @@ Feature: Campus Bookings Feature
   Examples:
    | username cbo   | password cbo | campusPin               | service address  | time  | assignment type      | email        | language |
    | zenq@cbo11.com | Test1        | 29449 - Contoso Pty LTD | jbcsjkwjscjknscj | 10:00 | CEO01-Interview-Home | hh@bb.com.au | ARABIC   |
+
+  #LL-897 Scenario #3: Verify that when a Campus is selected the address of the campus displays below the Service Address field also
+ @LL-897 @CampusSelectedAddressDisplayed
+ Scenario Outline: Verify that when a Campus is selected the address of the campus displays below the Service Address field also
+  When I login with "<username cbo>" and "<password cbo>"
+  And I click Interpreting header link
+  And I click on new job request button
+  And I select campus pin "<campusPin>" from Campus PIN dropdown
+  Then the selected address "<service address>" is displayed under the Service Address field
+
+  Examples:
+   | username cbo   | password cbo | campusPin               | service address                                   |
+   | zenq@cbo11.com | Test1        | 29449 - Contoso Pty LTD | Lysterfield Dr, Roxburgh Park VIC 3064, Australia |

--- a/test/features/InterpretingBookingManagement/CancelBookings.feature
+++ b/test/features/InterpretingBookingManagement/CancelBookings.feature
@@ -103,3 +103,22 @@ Feature: Cancel existing booking
    | NES client no-show                              | Automation Tester | short notice      | LLAdmin@looped.in  | Octopus@6    | Management     |  33124     |  Automation Tester  |  AFRIKAANS | Zero min ongoing | fortnight after | 09:30 | 4 hours  | hh@bb.com.au | Unallocated | Allocated             |
    | Job request error (Date,Time, Duration, etc..)  | Automation Tester | short notice      | LLAdmin@looped.in  | Octopus@6    | Management     |  33124     |  Automation Tester  |  AFRIKAANS | Zero min ongoing | fortnight after | 09:30 | 4 hours  | hh@bb.com.au | Unallocated | Allocated             |
    | Job request error (Date,Time, Duration, etc..)  | Automation Tester | two hours after   | LLAdmin@looped.in  | Octopus@6    | Management     |  33124     |  Automation Tester  |  AFRIKAANS | Zero min ongoing | fortnight after | 09:30 | 4 hours  | hh@bb.com.au | Unallocated | Allocated             |
+
+#LL-899 Scenario #1: Verifying the new cancellation reasons exists in the dropdown
+ @LL-899 @VerifyNewCancellationReasons
+ Scenario Outline: Verifying the new cancellation reasons exists in the dropdown
+  When I login with "<username>" and "<password>"
+  And I create a new job request with minimal fields "<job notice length>"
+  And I click Interpreting header link
+  And I search for created job request
+  And I click on job id from interpreting job search results
+  And I switch to the job allocation window
+  And I refresh the page
+  And I set the contractor job status from "Auto Notification" to "<contractor job status>"
+  And I click on Cancel button
+  And I confirm yes to cancellation fee
+  Then the new cancellation reasons "<cancellation reason new options>" should be displayed
+
+  Examples:
+   | job notice length | username          | password  | cancellation reason new options                               | contractor job status |
+   | short notice      | LLAdmin@looped.in | Octopus@6 | NAATI credential issue,Language/dialect issue,Technical issue | Allocated             |

--- a/test/pages/Booking/JobDetailsPage.js
+++ b/test/pages/Booking/JobDetailsPage.js
@@ -208,4 +208,8 @@ module.exports = {
     get customFieldsSection() {
         return $('//span[text()="Custom Fields"]/parent::div');
     },
+
+    get cancelReasonDropdownOptionDynamicLocator() {
+        return '//*[text()="Reason"]/../..//select/option[text()="<dynamic>"]';
+    },
 }

--- a/test/stepdefinition/Booking/JobDetailsSteps.js
+++ b/test/stepdefinition/Booking/JobDetailsSteps.js
@@ -287,3 +287,13 @@ Then(/^they will see the custom fields section under job info$/, function () {
     let customFieldsSectionDisplayStatus = action.isVisibleWait(jobDetailsPage.customFieldsSection, 10000, "Custom Fields section in Job Details page");
     chai.expect(customFieldsSectionDisplayStatus).to.be.true;
 })
+
+Then(/^the new cancellation reasons "(.*)" should be displayed$/, function (cancellationReasons) {
+    let cancellationReasonsList = cancellationReasons.split(",");
+    action.isVisibleWait(jobDetailsPage.cancelReasonDropdown, 10000, "Cancel reason dropdown in Job Details page");
+    for (let optionIndex = 0; optionIndex < cancellationReasonsList.length; optionIndex++) {
+        let cancelReasonDropdownOptionElement = $(jobDetailsPage.cancelReasonDropdownOptionDynamicLocator.replace("<dynamic>", cancellationReasonsList[optionIndex]));
+        let cancelReasonDropdownOptionExistStatus = action.isExistingWait(cancelReasonDropdownOptionElement, 10000, "Cancellation Reason option-" + cancellationReasonsList[optionIndex] + " in Job Details page");
+        chai.expect(cancelReasonDropdownOptionExistStatus).to.be.true;
+    }
+})

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -872,9 +872,14 @@ Then(/^the contractor "(.*)" on hovering over will give the message as ‘Insuff
 })
 
 Then(/^the selected address "(.*)" is displayed under the Service Address field$/, function (expectedAddress) {
-  action.isVisibleWait(jobRequestPage.addressTextUnderServiceAddressField,10000,"Address Under Service Address Field in Job request page");
-  let addressTextUnderServiceAddressFieldActual = action.getElementText(jobRequestPage.addressTextUnderServiceAddressField,"Address Under Service Address Field in Job request page");
-  chai.expect(addressTextUnderServiceAddressFieldActual).to.equal(expectedAddress)
+  action.isVisibleWait(jobRequestPage.addressTextUnderServiceAddressField, 10000, "Address Under Service Address Field in Job request page");
+  browser.waitUntil(() => action.getElementText(jobRequestPage.addressTextUnderServiceAddressField, "Address Under Service Address Field in Job request page").includes(expectedAddress) === true, {
+    timeout: 10000,
+    timeoutMsg: 'address is not displayed after 10sec',
+    interval: 500
+  })
+  let addressTextUnderServiceAddressFieldActual = action.getElementText(jobRequestPage.addressTextUnderServiceAddressField, "Address Under Service Address Field in Job request page");
+  chai.expect(addressTextUnderServiceAddressFieldActual).to.equal(expectedAddress);
 });
 
 Then(/^the error message Please click the map or select the address from suggestion list address is displayed$/, function () {


### PR DESCRIPTION
- Added locators in Job details page.
- Added step methods to verify the new cancellation reasons options are be displayed and updated step to verify the selected address is displayed under the Service Address field.
- Automated scenario 3 in LL-897 ticket under Release 23.05-1.
- Started and automated scenarios 1 in LL-899 ticket under Release 23.05-1.