### PR TITLE
Automated scenario 1 in LL-881 ticket

### DIFF
--- a/test/features/ODTI/ODTIJobsAdmin.feature
+++ b/test/features/ODTI/ODTIJobsAdmin.feature
@@ -424,3 +424,20 @@ Feature: ODTI Jobs Admin features
     Examples:
       | username          | password  | filter option 1 | filter option index 1 | filter comparator 1 | filter comparator index 1 | filter value 1 | filter value index 1 | filter option 2 | filter option index 2 | filter comparator 2 | filter comparator index 2 | filter value 2 | filter value index 2 | start date dashboard | end date dashboard |
       | LLAdmin@looped.in | Octopus@6 | Job Date        | 2                     | After               | 2                         | 01-03-2023     | 1                    | Job Date        | 3                     | Before              | 3                         | 05-09-2023     | 2                    | 02-03-2023           | 04-09-2023         |
+
+    #LL-901 Scenario 1: Verifying the explanation text for the Total/Connected count
+  @LL-901 @VerifyExplanationTextTotalConnectedCount
+  Scenario Outline: Verifying the explanation text for the Total/Connected count
+    When I login with "<username>" and "<password>"
+    And I click ODTI header link
+    And user is on ODTI > Language Serviceability
+    And user hover over TOTAL CALLS field in Language Serviceability
+    Then Total calls received for all languages, including unanswered calls text is displayed
+    And user hover over TOTAL CALLS CONNECTED field in Language Serviceability
+    And Total calls where atleast one interpreter was connected to the call, even for less than 60seconds text is displayed
+    And user hover over SERVICEABILITY % field in Language Serviceability
+    And Total calls connected by Total calls text is displayed
+
+    Examples:
+      | username          | password  |
+      | LLAdmin@looped.in | Octopus@6 |

--- a/test/pages/ODTI/ODTILanguageServiceabilityPage.js
+++ b/test/pages/ODTI/ODTILanguageServiceabilityPage.js
@@ -1,0 +1,26 @@
+module.exports = {
+
+    get totalCallsInfoIcon() {
+        return $('//div[text()="Total Calls"]/span/span');
+    },
+
+    get totalCallsInfoIconText() {
+        return $('//span[text()="Total calls received for all languages, including unanswered calls"]');
+    },
+
+    get totalCallsConnectedInfoIcon() {
+        return $('//div[text()="Total Calls Connected"]/span/span');
+    },
+
+    get totalCallsConnectedInfoIconText() {
+        return $('//span[text()="Total calls where atleast one interpreter was connected to the call, even for less than 60seconds"]');
+    },
+
+    get serviceabilityPercentageInfoIcon() {
+        return $('//div[text()="Serviceability %"]/span/span');
+    },
+
+    get serviceabilityPercentageInfoIconText() {
+        return $('//span[text()="Total calls connected/Total calls"]');
+    },
+}

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -759,3 +759,12 @@ When(/^user navigates to ODTI Dashboard$/, function () {
     let optionSelectedStatus = action.isSelectedWait(ODTIJobsOptionInTitleDropdown, 10000,"ODTI Dashboard dropdown in Title dropdown in ODTI Jobs page");
     chai.expect(optionSelectedStatus).to.be.true;
 })
+
+When(/^user is on ODTI > Language Serviceability$/, function () {
+    action.isVisibleWait(ODTIJobsPage.titleDropdown, 10000,"Title dropdown in ODTI Jobs page");
+    action.selectTextFromDropdown(ODTIJobsPage.titleDropdown, "Language Serviceability","Title dropdown in ODTI Jobs page");
+    let ODTIJobsOptionInTitleDropdown = $(ODTIJobsPage.titleDropdownOption.replace("<dynamic>", "Language Serviceability"));
+    let optionSelectedStatus = action.isSelectedWait(ODTIJobsOptionInTitleDropdown, 10000,"Language Serviceability dropdown in Title dropdown in ODTI Jobs page");
+    chai.expect(optionSelectedStatus).to.be.true;
+    action.waitUntilLoadingIconDisappears();
+})

--- a/test/stepdefinition/ODTI/ODTILanguageServiceabilitySteps.js
+++ b/test/stepdefinition/ODTI/ODTILanguageServiceabilitySteps.js
@@ -1,0 +1,53 @@
+When(/^user hover over TOTAL CALLS field in Language Serviceability$/, function () {
+    action.isVisibleWait(ODTILanguageServiceabilityPage.totalCallsInfoIcon,10000,"TOTAL CALLS info icon in ODTI Language Serviceability Page");
+    browser.execute((el) => {
+        const hoverEvent = new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window
+        });
+        el.dispatchEvent(hoverEvent);
+    }, ODTILanguageServiceabilityPage.totalCallsInfoIcon);
+    logger.info("Hovered mouse over TOTAL CALLS info icon in ODTI Language Serviceability Page");
+});
+
+Then(/^Total calls received for all languages, including unanswered calls text is displayed$/, function () {
+    let totalCallsInfoIconTextExistStatus = action.isExistingWait(ODTILanguageServiceabilityPage.totalCallsInfoIconText, 10000, "TOTAL CALLS info icon text Total calls received for all languages, including unanswered calls in ODTI Language Serviceability Page");
+    chai.expect(totalCallsInfoIconTextExistStatus).to.be.true;
+});
+
+When(/^user hover over TOTAL CALLS CONNECTED field in Language Serviceability$/, function () {
+    action.isVisibleWait(ODTILanguageServiceabilityPage.totalCallsConnectedInfoIcon,10000,"TOTAL CALLS CONNECTED info icon in ODTI Language Serviceability Page");
+    browser.execute((el) => {
+        const hoverEvent = new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window
+        });
+        el.dispatchEvent(hoverEvent);
+    }, ODTILanguageServiceabilityPage.totalCallsConnectedInfoIcon);
+    logger.info("Hovered mouse over TOTAL CALLS CONNECTED info icon in ODTI Language Serviceability Page");
+});
+
+Then(/^Total calls where atleast one interpreter was connected to the call, even for less than 60seconds text is displayed$/, function () {
+    let totalCallsConnectedInfoIconTextExistStatus = action.isExistingWait(ODTILanguageServiceabilityPage.totalCallsConnectedInfoIconText, 10000, "TOTAL CALLS CONNECTED info icon text Total calls where atleast one interpreter was connected to the call, even for less than 60seconds in ODTI Language Serviceability Page");
+    chai.expect(totalCallsConnectedInfoIconTextExistStatus).to.be.true;
+});
+
+When(/^user hover over SERVICEABILITY % field in Language Serviceability$/, function () {
+    action.isVisibleWait(ODTILanguageServiceabilityPage.serviceabilityPercentageInfoIcon,10000,"SERVICEABILITY % info icon in ODTI Language Serviceability Page");
+    browser.execute((el) => {
+        const hoverEvent = new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            view: window
+        });
+        el.dispatchEvent(hoverEvent);
+    }, ODTILanguageServiceabilityPage.serviceabilityPercentageInfoIcon);
+    logger.info("Hovered mouse over SERVICEABILITY % info icon in ODTI Language Serviceability Page");
+});
+
+Then(/^Total calls connected by Total calls text is displayed$/, function () {
+    let totalCallsConnectedInfoIconTextExistStatus = action.isExistingWait(ODTILanguageServiceabilityPage.serviceabilityPercentageInfoIconText, 10000, "SERVICEABILITY % info icon text Total calls connected/Total calls in ODTI Language Serviceability Page");
+    chai.expect(totalCallsConnectedInfoIconTextExistStatus).to.be.true;
+});

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -39,6 +39,7 @@ var ODTIJobDetailsPage = require('./test/pages/ODTI/ODTIJobDetails.js')
 var adminToolsHomePage = require('./test/pages/AdminTools/HomePage.js')
 var ODTIContractorsPage = require('./test/pages/AdminTools/ODTIContractorsPage.js')
 var ODTIDashboardPage = require('./test/pages/ODTI/ODTIDashboardPage.js')
+var ODTILanguageServiceabilityPage = require('./test/pages/ODTI/ODTILanguageServiceabilityPage.js')
 
 var chai= require('chai')
 var action=require('./test/utils/actions')
@@ -365,6 +366,7 @@ exports.config = {
         global.ODTIContractorsPage = ODTIContractorsPage
         global.translationsPage=translationsPage
         global.ODTIDashboardPage=ODTIDashboardPage
+        global.ODTILanguageServiceabilityPage=ODTILanguageServiceabilityPage
         //global.xtmPage = xtmPage
         
      },


### PR DESCRIPTION
- Added locators in ODTI Language Serviceability page.
- Added global page variables in wdio conf file.
- Added step methods to navigate to ODTI Language Serviceability, hover over TOTAL CALLS, TOTAL CALLS CONNECTED and SERVICEABILITY % fields and verify Total calls received for all languages, including unanswered calls, Total calls where atleast one interpreter was connected to the call, even for less than 60seconds, Total calls connected by Total calls messages are displayed respectively.
- Automated scenario 1 in LL-881 ticket under Release 23.07-1.