### PR TITLE
Automated scenario 4 in LL-925 ticket

### DIFF
--- a/test/features/AccountManagement/ContractManagement.feature
+++ b/test/features/AccountManagement/ContractManagement.feature
@@ -263,6 +263,10 @@ Feature: Contract Management features
   And I search for contract title "<contract title>"
   And I click the contract link "<contract title>" from search results
   And they remove added preference type option "<preference type option>" in Contract Details
+  And I click account management link
+  And I search for campus "<campus id>"
+  And I click the first campus link from search results
+  And they remove added preference type option "<preference type option>" in Campus Details
 
   Examples:
    | username          | password  | contract title                                   | preference type option | campus id | preference | override preference |

--- a/test/features/InterpretingBookingManagement/BookingsAllocations.feature
+++ b/test/features/InterpretingBookingManagement/BookingsAllocations.feature
@@ -503,3 +503,39 @@ Feature: Bookings Allocations Features
     Examples:
       | username          | password  | job notice length | contractor   | original status                 | new status | contractor username     | contractor password | allocated jobs option |
       | LLAdmin@looped.in | Octopus@6 | long notice       | Suzane HANNA | Auto Notification,- No status - | Allocated  | suzanehanna@hotmail.com | Test1               | Allocated Jobs        |
+
+    #LL-925 Scenario 4: Confirmed Return AFTER Job Handback Exclusion Zone
+  @LL-925 @ContractorConfirmedReturnAfterHEZ
+  Scenario Outline: Confirmed Return AFTER Job Handback Exclusion Zone
+    When I login with "<username>" and "<password>"
+    And I create a new job request with minimal fields "<job notice length>"
+    And I search for created job request
+    And I verify the job is listed in search results
+    And I click on first job id from interpreting job list
+    And I switch to the job allocation window
+    And search for contractor "<contractor>" in Job Allocation
+    And I change the contractor "<contractor>" job status from "<original status>" to "<new status>"
+    And I handle duplicate job updated warning message by refreshing browser and change contractor "<contractor>" status "<original status>","<new status>"
+    And I confirm the job status "<new status>"
+    And the looped in login page is opened
+    And I login with "<contractor username>" and "<contractor password>"
+    And I select "<allocated jobs option>" from the filter dropdown
+    And I search for selected job request
+    And I verify the job is listed in search results
+    And I click on first job id from interpreting job list
+    And they clicked on the Return Job button
+    Then a error message Please note you can’t return this job on the portal You will need to call us to return your job is displayed
+    And the job is not returned and no changes are saved
+    And the looped in login page is opened
+    And I login with "<username>" and "<password>"
+    And I click Interpreting header link
+    And I select "<management filter>" from the filter dropdown
+    And I search for created job request
+    And I verify the job is listed in search results
+    And I click on first job id from interpreting job list
+    And I switch to the job allocation window
+    And the booking is cancelled on behalf of "<Requester Name>"
+
+    Examples:
+      | username          | password  | job notice length | contractor   | original status                 | new status | contractor username     | contractor password | allocated jobs option | management filter | Requester Name    |
+      | LLAdmin@looped.in | Octopus@6 | short notice      | Suzane HANNA | Auto Notification,- No status - | Allocated  | suzanehanna@hotmail.com | Test1               | Allocated Jobs        | Management        | Automation Tester |

--- a/test/pages/Interpreting/InterpretingPage.js
+++ b/test/pages/Interpreting/InterpretingPage.js
@@ -117,4 +117,8 @@ module.exports={
         return '//select[@class="BorderlessShadowlessDropdown"]/option[text()="<dynamic>"]';
     },
 
+    get cantReturnJobCallUsErrorMessageText() {
+        return $('//span[text()="Please note you can’t return this job on the portal. You will need to call us to return your job."]');
+    },
+
 }

--- a/test/stepdefinition/Interpreting/InterpretingSteps.js
+++ b/test/stepdefinition/Interpreting/InterpretingSteps.js
@@ -389,3 +389,8 @@ Then(/^I verify the job is not listed in search results$/, function () {
   let jobIdLinkFromSearchResultIsExisting = action.isExistingWait(interpretingPage.jobIdLinkFromSearchResult,1000, "Job ID " + GlobalData.CURRENT_JOB_ID + " link from search result in Interpreting steps");
   chai.expect(jobIdLinkFromSearchResultIsExisting).to.be.false
 })
+
+Then(/^a error message Please note you can’t return this job on the portal You will need to call us to return your job is displayed$/, function () {
+  let cantReturnJobCallUsErrorMessageTextIsDisplayed = action.isVisibleWait(interpretingPage.cantReturnJobCallUsErrorMessageText,10000, "Please note you can’t return this job on the portal. You will need to call us to return your job. error message in Interpreting steps");
+  chai.expect(cantReturnJobCallUsErrorMessageTextIsDisplayed).to.be.true
+})


### PR DESCRIPTION
- Fixed failed scenario Scenario 1a in LL-324 by adding steps to remove the added preference type option in campus.
- Added locators in interpreting page.
- Added step methods to verify the error message Please note you can’t return this job on the portal You will need to call us to return your job is displayed.
- Automated scenario 4 in LL-925 ticket under Release 23.07-1 - Completed.