### PR TITLE
Automated scenario 1 in LL-936 ticket

### DIFF
--- a/test/features/InterpretingBookingManagement/BookingsAllocations.feature
+++ b/test/features/InterpretingBookingManagement/BookingsAllocations.feature
@@ -643,3 +643,25 @@ Feature: Bookings Allocations Features
     Examples:
       | username          | password  | job notice length  | contractor   | original status                 | allocated status | returned status |
       | LLAdmin@looped.in | Octopus@6 | short notice       | Suzane HANNA | Auto Notification,- No status - | Allocated        | Returned        |
+
+    #LL-936 Scenario 1 : Job has not been returned
+  @LL-936 @JobHasNotBeenReturned
+  Scenario Outline: Job has not been returned
+    When I login with "<username>" and "<password>"
+    And I create a new job request with minimal fields "<job notice length>"
+    And I search for created job request
+    And I verify the job is listed in search results
+    And I click on first job id from interpreting job list
+    And I switch to the job allocation window
+    And search for contractor "<contractor>" in Job Allocation
+    And I change the contractor "<contractor>" job status from "<original status>" to "<allocated status>"
+    And I handle duplicate job updated warning message by refreshing browser and change contractor "<contractor>" status "<original status>","<allocated status>"
+    And I confirm the job status "<allocated status>"
+    And the user is on the Job Detail page
+    Then the Late Job Return checkbox and label are displayed
+    And the Job Return checkbox is unchecked and is read-only
+    And the Job Return checkbox label is "<Late Job Return label>"
+
+    Examples:
+      | username          | password  | job notice length | contractor   | original status                 | allocated status | Late Job Return label |
+      | LLAdmin@looped.in | Octopus@6 | long notice       | Suzane HANNA | Auto Notification,- No status - | Allocated        | Late Job Return       |

--- a/test/pages/Booking/JobDetailsPage.js
+++ b/test/pages/Booking/JobDetailsPage.js
@@ -224,4 +224,16 @@ module.exports = {
     get returnJobPopupCancelButton() {
         return $('//input[contains(@id,"JobReturnDialog") and @value="Cancel"]')
     },
+
+    get lateJobReturnCheckbox() {
+        return $('//input[contains(@id,"LateChekcbox2")]');
+    },
+
+    get lateJobReturnCheckboxLabelText() {
+        return $('//span[text()="Late Job Return"]');
+    },
+
+    get lateJobReturnCheckboxLabel() {
+        return $('//input[contains(@id,"LateChekcbox2")]/parent::div/following-sibling::div/span');
+    },
 }

--- a/test/stepdefinition/AccountManagement/CampusSteps.js
+++ b/test/stepdefinition/AccountManagement/CampusSteps.js
@@ -1,6 +1,7 @@
 
 When(/^I click add campus link$/, function(){
     browser.pause(2000)
+    action.isVisibleWait(accountManagementPage.createCampusLink,20000,"Create Campus Link in campus page")
     action.clickElement(accountManagementPage.createCampusLink,"Create Campus Link in campus page")
     browser.pause(2000)
 
@@ -11,9 +12,11 @@ When(/^I select campus type "(.*)"$/, function(campustype)
     switch(campustype)
     {
         case "Metro":
+            action.isVisibleWait(accountManagementPage.metroRadioButton,20000,"Metro radio button in campus page")
             action.clickElement(accountManagementPage.metroRadioButton,"Metro radio button in campus page")
             break
         case "Regional":
+            action.isVisibleWait(accountManagementPage.regionalRadioButton,20000,"Regional radio button in campus page")
             action.clickElement(accountManagementPage.regionalRadioButton,"Regional radio button in campus page")
             break
         default:

--- a/test/stepdefinition/Booking/JobDetailsSteps.js
+++ b/test/stepdefinition/Booking/JobDetailsSteps.js
@@ -297,3 +297,29 @@ Then(/^the new cancellation reasons "(.*)" should be displayed$/, function (canc
         chai.expect(cancelReasonDropdownOptionExistStatus).to.be.true;
     }
 })
+
+When(/^the user is on the Job Detail page$/, function () {
+    browser.refresh()
+    action.isVisibleWait(ODTIInterpretersPage.jobIDTextInODTIJobAllocationPage, 10000,"Job Id in Job details page");
+    let currentInterpreterPageUrl = action.getPageUrl();
+    chai.expect(currentInterpreterPageUrl).to.includes("BookingJobAllocation.aspx");
+})
+
+Then(/^the Late Job Return checkbox and label are displayed$/, function () {
+    let lateJobReturnCheckboxIsDisplayed = action.isVisibleWait(jobDetailsPage.lateJobReturnCheckbox, 10000,"Late Job Return checkbox in Job details page");
+    chai.expect(lateJobReturnCheckboxIsDisplayed).to.be.true;
+    let lateJobReturnCheckboxLabelTextIsDisplayed = action.isVisibleWait(jobDetailsPage.lateJobReturnCheckboxLabelText, 10000,"Late Job Return checkbox label text in Job details page");
+    chai.expect(lateJobReturnCheckboxLabelTextIsDisplayed).to.be.true;
+})
+
+Then(/^the Job Return checkbox is unchecked and is read-only$/, function () {
+    let lateJobReturnCheckboxIsSelected = action.isSelectedWait(jobDetailsPage.lateJobReturnCheckbox, 1000,"Late Job Return checkbox in Job details page");
+    chai.expect(lateJobReturnCheckboxIsSelected).to.be.false;
+    let lateJobReturnCheckboxIsClickable = action.isClickableWait(jobDetailsPage.lateJobReturnCheckbox, 1000,"Late Job Return checkbox in Job details page");
+    chai.expect(lateJobReturnCheckboxIsClickable).to.be.false;
+})
+
+Then(/^the Job Return checkbox label is "(.*)"$/, function (checkboxLabel) {
+    let lateJobReturnCheckboxLabelActual = action.getElementText(jobDetailsPage.lateJobReturnCheckboxLabel,"Late Job Return checkbox label in Job details page");
+    chai.expect(lateJobReturnCheckboxLabelActual).to.equal(checkboxLabel);
+})

--- a/test/stepdefinition/Booking/JobRequestSteps.js
+++ b/test/stepdefinition/Booking/JobRequestSteps.js
@@ -420,11 +420,13 @@ Given(/^Fill out all the required details "(.*)", email, "(.*)"$/, function(firs
 When(/^They click the Save button$/, function(){
   action.isClickableWait(jobRequestPage.saveButtonBookingOfficer,10000,"Save button booking officer in Job request page");
   action.clickElement(jobRequestPage.saveButtonBookingOfficer,"Save button booking officer in Job request page");
+  action.isNotVisibleWait(jobRequestPage.saveButtonBookingOfficer,20000,"Save button booking officer in Job request page");
 })
 
 Then(/^The user is created in job request$/,function(){
+  action.waitUntilLoadingIconDisappears()
   let requesterNameTextActual = $(jobRequestPage.requesterNameTextValueLocator.replace("<dynamic>",GlobalData.BOOKING_OFFICER_FIRSTNAME))
-  let requesterNameDisplayStatus = action.isVisibleWait(requesterNameTextActual,10000,"Requester name text in Job request page");
+  let requesterNameDisplayStatus = action.isVisibleWait(requesterNameTextActual,30000,"Requester name text in Job request page");
   chai.expect(requesterNameDisplayStatus).to.be.true;
 })
 


### PR DESCRIPTION
- Added waits to fix synchronization issues.
- Added locators in job details page.
- Added step methods to check the user is on the Job Detail page, to verify the Late Job Return checkbox and label are displayed, the Job Return checkbox is unchecked and is read-only and the Job Return checkbox label is Late Job Return.
- Automated scenario 1 in LL-936 ticket under Release 23.07-1.
