### PR TITLE
Fixed the failed test scenarios

### DIFF
--- a/test/features/ODTI/ODTIJobsCSO.feature
+++ b/test/features/ODTI/ODTIJobsCSO.feature
@@ -169,7 +169,7 @@ Feature: ODTI Jobs CSO features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And The RecordStatus Is Export
-    And I click on a Campus Name value under Campus Name column
+    And I click on a non empty Campus Name value under Campus Name column
     Then I should be navigated to the Campus detail page "<Campus detail page url>" of the respective Campus that is clicked
 
     Examples:
@@ -267,7 +267,7 @@ Feature: ODTI Jobs CSO features
     When I login with "<username cso>" and "<password cso>"
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
-    And I click on a Job ID value under ODTI SERVICE CHARGE ID column
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And the user is viewing the Job Details page
     Then they will see the Campus PIN hyperlinked
     And they click the Campus PIN
@@ -283,7 +283,7 @@ Feature: ODTI Jobs CSO features
     When I login with "<username cso>" and "<password cso>"
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
-    And I click on a Job ID value under ODTI SERVICE CHARGE ID column
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And the user is viewing the Job Details page
     Then they will see the Contract Name hyperlinked
     And they click the Contract Name

--- a/test/features/ODTI/ODTIJobsFinance.feature
+++ b/test/features/ODTI/ODTIJobsFinance.feature
@@ -53,7 +53,7 @@ Feature: ODTI Jobs Finance features
     And this will only display jobs that have been Completed Billing & Merging processes done
     Then The columns available for ODTI Jobs for the user are "<column headers>"
     And the relevant information will be shown under each column
-    And ODTI Service Charge ID, Campus Name and Interpreter Name will all be hyperlinked and in bold font weight
+    And ODTI Service Charge ID, non empty Campus Name and Interpreter Name will all be hyperlinked and in bold font weight
     And the number of records will be displayed at the bottom of the table as per existing functionality
     And the user will not see the "<column header not displayed>" column
 
@@ -71,7 +71,7 @@ Feature: ODTI Jobs Finance features
     And this will only display jobs that have been Completed Billing & Merging processes done
     Then The columns available for ODTI Jobs for the user are "<column headers>"
     And the relevant information will be shown under each column
-    And ODTI Service Charge ID, Campus Name and Interpreter Name will all be hyperlinked and in bold font weight
+    And ODTI Service Charge ID, non empty Campus Name and Interpreter Name will all be hyperlinked and in bold font weight
     And the number of records will be displayed at the bottom of the table as per existing functionality
 
     Examples:
@@ -85,9 +85,9 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     Then they are navigated to the Job Details page in a new tab
-    And they click the Campus Name hyperlink
+    And they click the non empty Campus Name hyperlink
     And they are navigated to the Campus Details page in a new tab
     And they click the Interpreter Name
     And they are navigated to the Interpreter’s Profile page in a new tab
@@ -103,7 +103,7 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And they are navigated to the Job Details page in a new tab
     And I want to change the campus pin by clicking on the Edit icon
     And I click on Migrate & Recalculate Job Fee without selecting a new campus pin
@@ -120,7 +120,7 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And they are navigated to the Job Details page in a new tab
     And I want to change the campus pin by clicking on the Edit icon
     And I select the new campus pin "<new campus pin>" which is for a different contract
@@ -137,7 +137,7 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And they are navigated to the Job Details page in a new tab
     And I want to change the campus pin by clicking on the Edit icon
     And I select the new campus pin "<new campus pin>" which is for a different contract
@@ -156,7 +156,7 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And they are navigated to the Job Details page in a new tab
     And I want to change the campus pin by clicking on the Edit icon
     And I select the new campus pin "<new campus pin>" which is for a different contract
@@ -174,7 +174,7 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And they are navigated to the Job Details page in a new tab
     And I want to change the campus pin by clicking on the Edit icon
     And I select the new campus pin "<new campus pin>" which is for a different contract
@@ -193,7 +193,7 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And they are navigated to the Job Details page in a new tab
     And I want to change the campus pin by clicking on the Edit icon
     Then a pop up will display the campus pin "<new campus pin>" in the results, and on hovering over message Campus is disabled
@@ -210,7 +210,7 @@ Feature: ODTI Jobs Finance features
     And I click ODTI header link
     And I view the ODTI > ODTI Jobs page
     And they will see a table
-    And they click the ODTI Service Charge ID hyperlink
+    And I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column
     And they are navigated to the Job Details page in a new tab
     And I want to change the campus pin by clicking on the Edit icon
     And I enter the campus pin "<new campus pin>" which does not exist

--- a/test/stepdefinition/ODTI/ODTIJobsSteps.js
+++ b/test/stepdefinition/ODTI/ODTIJobsSteps.js
@@ -775,3 +775,71 @@ When(/^they click on any of the ODTI Service Charge ID hyperlink$/, function () 
     action.isVisibleWait(serviceChargeID1TextElement, 10000,"Service charge ID in ODTI Jobs page");
     action.clickElement(serviceChargeID1TextElement,"Service charge ID in ODTI Jobs page");
 })
+
+When(/^I click on a non empty Campus Name value under Campus Name column$/, function () {
+    browser.pause(5000);
+    action.waitUntilLoadingIconDisappears();
+    let totalRowsCount = ODTIJobsPage.totalRowCount;
+    let firstCampusNameElement;
+    for (let row = 1; row <= totalRowsCount; row++) {
+        firstCampusNameElement = $(ODTIJobsPage.columnValueLinkLocator.replace("<dynamic1>", row.toString()).replace("<dynamic2>", "4"));
+        if (action.getElementText(firstCampusNameElement, "First campus name in ODTI Job details page") !== "") {
+            break;
+        }
+    }
+    action.isVisibleWait(firstCampusNameElement, 10000);
+    GlobalData.ODTI_CAMPUS_NAME = action.getElementText(firstCampusNameElement, "First campus name in ODTI Job details page");
+    action.clickElement(firstCampusNameElement, "First campus name in ODTI Job details page");
+})
+
+When(/^I click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column$/, function () {
+    browser.pause(5000);
+    action.waitUntilLoadingIconDisappears();
+    let totalRowsCount = ODTIJobsPage.totalRowCount;
+    let firstCampusNameElement;
+    let row;
+    for (row = 1; row <= totalRowsCount; row++) {
+        firstCampusNameElement = $(ODTIJobsPage.columnValueLinkLocator.replace("<dynamic1>", row.toString()).replace("<dynamic2>", "4"));
+        if (action.getElementText(firstCampusNameElement, "First campus name in ODTI Job details page") !== "") {
+            break;
+        }
+    }
+    let jobIdFirstValueElement = $(ODTIJobsPage.columnValueLinkLocator.replace("<dynamic1>", row.toString()).replace("<dynamic2>", "1"));
+    action.isVisibleWait(jobIdFirstValueElement, 10000);
+    GlobalData.ODTI_SERVICE_CHARGE_JOB_ID_IN_TABLE = action.getElementText(jobIdFirstValueElement, "Job Id first value in ODTI Jobs page");
+    action.clickElement(jobIdFirstValueElement, "Job Id first value in ODTI Jobs page");
+})
+
+When(/^ODTI Service Charge ID, non empty Campus Name and Interpreter Name will all be hyperlinked and in bold font weight$/, function () {
+    let serviceChargeID1TextElement = $(ODTIJobsPage.odtiTableResultsHyperlinkDataElementLocator.replace("<dynamicColumnIndex>", "1"));
+    let serviceChargeIDHyperlinkDisplayStatus = action.isVisibleWait(serviceChargeID1TextElement, 10000,"Service charge ID in ODTI Jobs page");
+    chai.expect(serviceChargeIDHyperlinkDisplayStatus).to.be.true;
+    let totalRowsCount = ODTIJobsPage.totalRowCount;
+    let firstCampusNameElement;
+    let row;
+    for (row = 1; row <= totalRowsCount; row++) {
+        firstCampusNameElement = $(ODTIJobsPage.columnValueLinkLocator.replace("<dynamic1>", row.toString()).replace("<dynamic2>", "4"));
+        if (action.getElementText(firstCampusNameElement, "First campus name in ODTI Job details page") !== "") {
+            break;
+        }
+    }
+    let campusNameHyperlinkDisplayStatus = action.isVisibleWait(firstCampusNameElement, 10000,"Campus name in ODTI Jobs page");
+    chai.expect(campusNameHyperlinkDisplayStatus).to.be.true;
+    let interpreterName1TextElement = $(ODTIJobsPage.odtiTableResultsHyperlinkDataElementLocator.replace("<dynamicColumnIndex>", "6"));
+    let interpreterNameHyperlinkDisplayStatus = action.isVisibleWait(interpreterName1TextElement, 10000,"Interpreter name in ODTI Jobs page");
+    chai.expect(interpreterNameHyperlinkDisplayStatus).to.be.true;
+})
+
+When(/^they click the non empty Campus Name hyperlink$/, function () {
+    action.navigateToWindowHandle(GlobalData.ODTI_JOBS_PAGE_WINDOW_HANDLE)
+    let totalRowsCount = ODTIJobsPage.totalRowCount;
+    let firstCampusNameElement;
+    for (let row = 1; row <= totalRowsCount; row++) {
+        firstCampusNameElement = $(ODTIJobsPage.columnValueLinkLocator.replace("<dynamic1>", row.toString()).replace("<dynamic2>", "4"));
+        if (action.getElementText(firstCampusNameElement, "First campus name in ODTI Job details page") !== "") {
+            break;
+        }
+    }
+    action.isVisibleWait(firstCampusNameElement, 10000,"Campus name in ODTI Jobs page");
+    action.clickElement(firstCampusNameElement,"Campus name in ODTI Jobs page");
+})


### PR DESCRIPTION
- Fixed the failed test scenarios by adding step methods to click on a non empty Campus Name value under Campus Name column, to click on a Job ID value with non empty campus under ODTI SERVICE CHARGE ID column, to click on the non empty Campus Name hyperlink and to verify ODTI Service Charge ID, non empty Campus Name and Interpreter Name will all be hyperlinked and in bold font weight.